### PR TITLE
fix: wasm execution when using Go 1.14+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,45 +1,43 @@
 name: Test
 on: [push]
 jobs:
-
   testgo:
     name: Go Tests
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go 1.14
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14
+        id: go
 
-    - name: Set up Go 1.13
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.13
-      id: go
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      - shell: bash
+        run: |
+          export GOPATH=$HOME/go
+          export GOBIN=$(go env GOPATH)/bin
+          export PATH=$PATH:$GOPATH
+          export PATH=$PATH:$GOBIN
+          mkdir -p $GOPATH/pkg
+          mkdir -p $GOBIN
+          mkdir -p $GOPATH/src/github.com/$GITHUB_REPOSITORY
+          mv ./* $GOPATH/src/github.com/$GITHUB_REPOSITORY
+          cd $GOPATH/src/github.com/$GITHUB_REPOSITORY/go-wasm
+          if [ -f Gopkg.toml ]; then
+              curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+              dep ensure
+          fi
+          go test -v ./...
+          env GOOS=js GOARCH=wasm go build -o ../build/wasm/main.wasm main.go
+          realpath ../build/wasm/main.wasm
 
-    - shell: bash
-      run: |
-        export GOPATH=$HOME/go
-        export GOBIN=$(go env GOPATH)/bin
-        export PATH=$PATH:$GOPATH
-        export PATH=$PATH:$GOBIN
-        mkdir -p $GOPATH/pkg
-        mkdir -p $GOBIN
-        mkdir -p $GOPATH/src/github.com/$GITHUB_REPOSITORY
-        mv ./* $GOPATH/src/github.com/$GITHUB_REPOSITORY
-        cd $GOPATH/src/github.com/$GITHUB_REPOSITORY/go-wasm
-        if [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-        fi
-        go test -v ./...
-        env GOOS=js GOARCH=wasm go build -o ../build/wasm/main.wasm main.go
-        realpath ../build/wasm/main.wasm
-
-    - name: Upload WASM
-      uses: actions/upload-artifact@v1
-      with:
-        name: wasm
-        path: ../../../go/src/github.com/${{ github.repository }}/build/wasm/main.wasm
+      - name: Upload WASM
+        uses: actions/upload-artifact@v1
+        with:
+          name: wasm
+          path: ../../../go/src/github.com/${{ github.repository }}/build/wasm/main.wasm
 
   testts:
     runs-on: ubuntu-latest
@@ -51,30 +49,30 @@ jobs:
         node-version: [10.x, 12.x]
 
     steps:
-    - name: Check out code
-      uses: actions/checkout@v1
+      - name: Check out code
+        uses: actions/checkout@v1
 
-    - name: Download wasm for Go Tests
-      uses: actions/download-artifact@v1
-      with:
-        name: wasm
+      - name: Download wasm for Go Tests
+        uses: actions/download-artifact@v1
+        with:
+          name: wasm
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-  
-    - name: yarn install, build, and test
-      run: |
-        mkdir -p build
-        ls
-        mv wasm build/wasm
-        yarn install --frozen-lockfile
-        yarn lint
-        yarn build:typescript
-        yarn testf
-      env:
-        CI: true
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: yarn install, build, and test
+        run: |
+          mkdir -p build
+          ls
+          mv wasm build/wasm
+          yarn install --frozen-lockfile
+          yarn lint
+          yarn build:typescript
+          yarn testf
+        env:
+          CI: true
 
   testintegration:
     runs-on: ubuntu-latest
@@ -82,28 +80,28 @@ jobs:
     needs: testgo
 
     steps:
-    - name: Check out code
-      uses: actions/checkout@v1
+      - name: Check out code
+        uses: actions/checkout@v1
 
-    - name: Download wasm for Go Tests
-      uses: actions/download-artifact@v1
-      with:
-        name: wasm
+      - name: Download wasm for Go Tests
+        uses: actions/download-artifact@v1
+        with:
+          name: wasm
 
-    - name: Use Node.js 10.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 10
-  
-    - name: yarn install and test
-      run: |
-        mkdir -p build
-        ls
-        mv wasm build/wasm
-        yarn install --frozen-lockfile
-        docker run -d --rm -p 9944:9944 kiltprotocol/portablegabi-node --dev --ws-port 9944 --ws-external
-        sleep 5s
-        yarn test:integration
-        docker stop $(docker ps -f ancestor=kiltprotocol/portablegabi-node -q)
-      env:
-        CI: true
+      - name: Use Node.js 10.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10
+
+      - name: yarn install and test
+        run: |
+          mkdir -p build
+          ls
+          mv wasm build/wasm
+          yarn install --frozen-lockfile
+          docker run -d --rm -p 9944:9944 kiltprotocol/portablegabi-node --dev --ws-port 9944 --ws-external
+          sleep 5s
+          yarn test:integration
+          docker stop $(docker ps -f ancestor=kiltprotocol/portablegabi-node -q)
+        env:
+          CI: true

--- a/README.md
+++ b/README.md
@@ -4,19 +4,24 @@
 
 This TypeScript module of Portable Gabi enables the use of [Idemix](http://www.research.ibm.com/labs/zurich/idemix/) attribute based anonymous credentials via NPM. It is based on the [Gabi Go](https://github.com/privacybydesign/gabi) implementation by the [Privacy By Design Foundation](https://privacybydesign.foundation/) but does not use the same API.
 
-A user (in the following referred to as "claimer") claiming something (e.g. citizenship in a specific country, ownership of a valid driver's license) can request an attestation from a trusted entity ("attester") and present these claims to multiple verifiers without revealing sensitive information uniquely tied to the claimer. The claimer can chose which attributes of the claim to disclose to a verifier.
-
-Note that due to the usage of a Go WASM via callbacks, all functions are asynchronous. It can happen that NodeJS does not exit automatically since we keep the WASM instance open. We recommend calling `goWasmClose()` from [wasm_exec_wrapper](src/wasm/wasm_exec_wrapper.ts) at the end of your process.
-
-This module can be used with and without a substrate based blockchain. However, it was designed to be used with a chain acting as a decentralised storage of each attester's accumulator versions. All processes tied to chain activity can be found in files with `chain` suffix. In order to use them, you are required to have an active [substrate](https://www.parity.io/substrate/) blockchain implementing the [`portablegabi-pallet`](https://github.com/KILTprotocol/portablegabi-pallet). You could clone and set up this [`portablegabi-node`](https://github.com/KILTprotocol/portablegabi-node) basic substrate template implementing the portablegabi-pallet.
+A user (in the following referred to as _claimer_) claiming something in JSON format (e.g. citizenship in a specific country, ownership of a valid driver's license) can request an attestation from a trusted entity (_attester_) and present these claims to multiple _verifiers_ without revealing their identity or sensitive information (**multi-show unlinkability**).
+The claimer can chose which attributes of the claim to disclose to a verifier (**selective disclosure**).
 
 ## Tutorial
 
-We recommend visiting our [Portablegabi tutorial](https://kiltprotocol.github.io/portablegabi-tutorial/) to explore the library with the best possible experience.
+We recommend visiting our [Portablegabi tutorial](https://kiltprotocol.github.io/portablegabi-tutorial/) to better und
+
+## Revocation and Substraze
+
+This module can be used with and without a [Substrate](https://www.parity.io/substrate/)-based blockchain.
+However, it was designed to be used with a chain acting as a decentralised storage of each attester's accumulator versions to enable revocation.
+All processes tied to chain activity can be found in files with `chain` suffix. In order to use them, you are required to have an active Substrate blockchain implementing our [`portablegabi-pallet`](https://github.com/KILTprotocol/portablegabi-pallet).
+We also provide a blockchain template which includes our pallet and can be used to store accumulators.
+In order to use that, just clone and set up the [`portablegabi-node`](https://github.com/KILTprotocol/portablegabi-node) or use the template to create your own project. Please see our tutorial for more information.
 
 ## Installing
 
-To build the package, you need to have [GO](https://golang.org/) and [dep](https://github.com/golang/dep) installed.
+To build the package, you need to have [Go 1.14+](https://golang.org/) and [dep](https://github.com/golang/dep) installed. We also recommend installing [yarn](https://yarnpkg.com/getting-started), so you can easily build the WASM.
 
 ```bash
 npm i @kiltprotocol/portablegabi
@@ -47,16 +52,16 @@ const claim = {
   },
 }
 
-// (1.2) Create claimer identity: Either from scratch or mnemonic seed
+// (1.2) Create the claimer identity (either from scratch or mnemonic seed).
 const claimer = await GabiClaimer.create()
 
 /* (2) Attester Setup */
 
-// (2.1) Create key pair and attester
+// (2.1) Create a key pair and attester entity.
 const attester = await GabiAttester.create(
   365 * 24 * 60 * 60 * 1000,
   70
-) // Takes very long due to finding safe prime numbers, ~10 minutes
+) // takes very long due to finding safe prime numbers (~10-20 minutes)
 
 // (2.1) Create accumulator (for revocation)
 const accumulator = await attester.createAccumulator()
@@ -79,8 +84,8 @@ const {
   attesterPubKey: attester.publicKey,
 })
 
-// (3.3) Attester issues requested attestation and generates a witness which can be used to revoke the attestation
-// the attester might want to inspect the attributes he is about to sign
+// (3.3) The Attester issues a requested attestation and generates a witness which can be used to revoke the attestation.
+// The attester might want to inspect the attributes he is about to sign.
 const checkClaim = attestationRequest.getClaim()
 
 const { attestation, witness } = await attester.issueAttestation({
@@ -89,7 +94,7 @@ const { attestation, witness } = await attester.issueAttestation({
   accumulator,
 })
 
-// (3.4) Claimer builds credential from attester's signature
+// (3.4) The Claimer builds credential from attester's signature.
 const credential = await claimer.buildCredential({
   claimerSession,
   attestation,
@@ -97,7 +102,7 @@ const credential = await claimer.buildCredential({
 
 /* (4) Verification */
 
-// (4.1) Verifier sends two nonces to claimer
+// (4.1) The verifier sends two nonces to claimer.
 const {
   session: verifierSession,
   message: presentationReq,
@@ -106,14 +111,14 @@ const {
   reqUpdatedAfter: new Date(), // request that the nonrevocation proof contains an accumulator which was created after this date or that the accumulator is the newest available
 })
 
-// (4.2) Claimer reveals attributes
+// (4.2) The Claimer reveals attributes.
 const proof = await claimer.buildPresentation({
   credential,
   presentationReq,
   attesterPubKey: attester.publicKey,
 })
 
-// (4.3) Verifier verifies attributes
+// (4.3) The Verifier verifies attributes.
 const {
   verified,
   claim: verifiedClaim,
@@ -126,20 +131,35 @@ const {
 
 /* (5) Revocation */
 
-// revoke witness of a credential
+// Revoke the witness of a credential.
 const accumulatorAfterRevocation = await attester.revokeAttestation({
   accumulator,
   witnesses: [other_witness, ...],
 })
 
-// all claimers have to update their own credential with the new update.
-// this will only work for non revoked credentials
+// All claimers have to update their own credential with the new update.
+// This will only work for non revoked credentials.
 credential = await claimer.updateCredential({
   credential,
   attesterPubKey: attester.publicKey,
   accumulator: accumulatorAfterRevocation,
 })
 ```
+
+# Troubleshooting
+
+## Node process did not exit automatically
+
+Note that due to the usage of a Go WASM via callbacks, all functions are asynchronous. It can happen that NodeJS does not exit automatically since we keep the WASM instance open. We recommend calling `goWasmClose()` from [wasm_exec_wrapper](src/wasm/wasm_exec_wrapper.ts) at the end of your process.
+
+## Go version below 1.14.1
+
+```bash
+  [LinkError: WebAssembly Instantiation: Import #3 module="go" function="runtime.nanotime" error: function import requires a callable]
+  (node:6909) UnhandledPromiseRejectionWarning: Error: Function genKey missing in WASM
+```
+
+Please check your Go version, it should be at least `1.14.1`. If this is the case for you, and you still encounter this problem without having modified our code, [please open a ticket](https://github.com/KILTprotocol/portablegabi/issues/new).
 
 ## Limitations
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kiltprotocol/portablegabi",
   "version": "0.0.2",
-  "description": "Portable version of the Gabi Go library for anonymous credential",
+  "description": "Typescript API and WASM wrapper of Go library Gabi enabling anonymous credentials",
   "main": "./build/index.js",
   "typings": "./build/index.d.ts",
   "scripts": {

--- a/src/wasm/wasm_exec.js
+++ b/src/wasm/wasm_exec.js
@@ -21,6 +21,12 @@ if (!global.fs && global.require) {
   global.fs = require('fs')
 }
 
+const enosys = () => {
+  const err = new Error('not implemented')
+  err.code = 'ENOSYS'
+  return err
+}
+
 if (!global.fs) {
   let outputBuf = ''
   global.fs = {
@@ -43,23 +49,111 @@ if (!global.fs) {
     },
     write(fd, buf, offset, length, position, callback) {
       if (offset !== 0 || length !== buf.length || position !== null) {
-        throw new Error('not implemented')
+        callback(enosys())
+        return
       }
       const n = this.writeSync(fd, buf)
       callback(null, n)
     },
-    open(path, flags, mode, callback) {
-      const err = new Error('not implemented')
-      err.code = 'ENOSYS'
-      callback(err)
+    chmod(path, mode, callback) {
+      callback(enosys())
     },
-    read(fd, buffer, offset, length, position, callback) {
-      const err = new Error('not implemented')
-      err.code = 'ENOSYS'
-      callback(err)
+    chown(path, uid, gid, callback) {
+      callback(enosys())
+    },
+    close(fd, callback) {
+      callback(enosys())
+    },
+    fchmod(fd, mode, callback) {
+      callback(enosys())
+    },
+    fchown(fd, uid, gid, callback) {
+      callback(enosys())
+    },
+    fstat(fd, callback) {
+      callback(enosys())
     },
     fsync(fd, callback) {
       callback(null)
+    },
+    ftruncate(fd, length, callback) {
+      callback(enosys())
+    },
+    lchown(path, uid, gid, callback) {
+      callback(enosys())
+    },
+    link(path, link, callback) {
+      callback(enosys())
+    },
+    lstat(path, callback) {
+      callback(enosys())
+    },
+    mkdir(path, perm, callback) {
+      callback(enosys())
+    },
+    open(path, flags, mode, callback) {
+      callback(enosys())
+    },
+    read(fd, buffer, offset, length, position, callback) {
+      callback(enosys())
+    },
+    readdir(path, callback) {
+      callback(enosys())
+    },
+    readlink(path, callback) {
+      callback(enosys())
+    },
+    rename(from, to, callback) {
+      callback(enosys())
+    },
+    rmdir(path, callback) {
+      callback(enosys())
+    },
+    stat(path, callback) {
+      callback(enosys())
+    },
+    symlink(path, link, callback) {
+      callback(enosys())
+    },
+    truncate(path, length, callback) {
+      callback(enosys())
+    },
+    unlink(path, callback) {
+      callback(enosys())
+    },
+    utimes(path, atime, mtime, callback) {
+      callback(enosys())
+    },
+  }
+}
+
+if (!global.process) {
+  global.process = {
+    getuid() {
+      return -1
+    },
+    getgid() {
+      return -1
+    },
+    geteuid() {
+      return -1
+    },
+    getegid() {
+      return -1
+    },
+    getgroups() {
+      throw enosys()
+    },
+    pid: -1,
+    ppid: -1,
+    umask() {
+      throw enosys()
+    },
+    cwd() {
+      throw enosys()
+    },
+    chdir() {
+      throw enosys()
     },
   }
 }
@@ -111,24 +205,19 @@ class Go {
     this._scheduledTimeouts = new Map()
     this._nextCallbackTimeoutID = 1
 
-    const mem = () => {
-      // The buffer may change when requesting more memory.
-      return new DataView(this._inst.exports.mem.buffer)
-    }
-
     const setInt64 = (addr, v) => {
-      mem().setUint32(addr + 0, v, true)
-      mem().setUint32(addr + 4, Math.floor(v / 4294967296), true)
+      this.mem.setUint32(addr + 0, v, true)
+      this.mem.setUint32(addr + 4, Math.floor(v / 4294967296), true)
     }
 
     const getInt64 = addr => {
-      const low = mem().getUint32(addr + 0, true)
-      const high = mem().getInt32(addr + 4, true)
+      const low = this.mem.getUint32(addr + 0, true)
+      const high = this.mem.getInt32(addr + 4, true)
       return low + high * 4294967296
     }
 
     const loadValue = addr => {
-      const f = mem().getFloat64(addr, true)
+      const f = this.mem.getFloat64(addr, true)
       if (f === 0) {
         return undefined
       }
@@ -136,7 +225,7 @@ class Go {
         return f
       }
 
-      const id = mem().getUint32(addr, true)
+      const id = this.mem.getUint32(addr, true)
       return this._values[id]
     }
 
@@ -145,57 +234,62 @@ class Go {
 
       if (typeof v === 'number') {
         if (isNaN(v)) {
-          mem().setUint32(addr + 4, nanHead, true)
-          mem().setUint32(addr, 0, true)
+          this.mem.setUint32(addr + 4, nanHead, true)
+          this.mem.setUint32(addr, 0, true)
           return
         }
         if (v === 0) {
-          mem().setUint32(addr + 4, nanHead, true)
-          mem().setUint32(addr, 1, true)
+          this.mem.setUint32(addr + 4, nanHead, true)
+          this.mem.setUint32(addr, 1, true)
           return
         }
-        mem().setFloat64(addr, v, true)
+        this.mem.setFloat64(addr, v, true)
         return
       }
 
       switch (v) {
         case undefined:
-          mem().setFloat64(addr, 0, true)
+          this.mem.setFloat64(addr, 0, true)
           return
         case null:
-          mem().setUint32(addr + 4, nanHead, true)
-          mem().setUint32(addr, 2, true)
+          this.mem.setUint32(addr + 4, nanHead, true)
+          this.mem.setUint32(addr, 2, true)
           return
         case true:
-          mem().setUint32(addr + 4, nanHead, true)
-          mem().setUint32(addr, 3, true)
+          this.mem.setUint32(addr + 4, nanHead, true)
+          this.mem.setUint32(addr, 3, true)
           return
         case false:
-          mem().setUint32(addr + 4, nanHead, true)
-          mem().setUint32(addr, 4, true)
+          this.mem.setUint32(addr + 4, nanHead, true)
+          this.mem.setUint32(addr, 4, true)
           return
       }
 
-      let ref = this._refs.get(v)
-      if (ref === undefined) {
-        ref = this._values.length
-        this._values.push(v)
-        this._refs.set(v, ref)
+      let id = this._ids.get(v)
+      if (id === undefined) {
+        id = this._idPool.pop()
+        if (id === undefined) {
+          id = this._values.length
+        }
+        this._values[id] = v
+        this._goRefCounts[id] = 0
+        this._ids.set(v, id)
       }
-      let typeFlag = 0
+      this._goRefCounts[id]++
+      let typeFlag = 1
       switch (typeof v) {
         case 'string':
-          typeFlag = 1
-          break
-        case 'symbol':
           typeFlag = 2
           break
-        case 'function':
+        case 'symbol':
           typeFlag = 3
           break
+        case 'function':
+          typeFlag = 4
+          break
       }
-      mem().setUint32(addr + 4, nanHead | typeFlag, true)
-      mem().setUint32(addr, ref, true)
+      this.mem.setUint32(addr + 4, nanHead | typeFlag, true)
+      this.mem.setUint32(addr, id, true)
     }
 
     const loadSlice = addr => {
@@ -227,16 +321,18 @@ class Go {
       go: {
         // Go's SP does not change as long as no Go code is running. Some operations (e.g. calls, getters and setters)
         // may synchronously trigger a Go event handler. This makes Go code get executed in the middle of the imported
-        // function. A goroutine can switch to a new stack if the current stack is too small (see moreStack function).
+        // function. A goroutine can switch to a new stack if the current stack is too small (see morestack function).
         // This changes the SP, thus we have to update the SP used by the imported function.
 
         // func wasmExit(code int32)
         'runtime.wasmExit': sp => {
-          const code = mem().getInt32(sp + 8, true)
+          const code = this.mem.getInt32(sp + 8, true)
           this.exited = true
           delete this._inst
           delete this._values
-          delete this._refs
+          delete this._goRefCounts
+          delete this._ids
+          delete this._idPool
           this.exit(code)
         },
 
@@ -244,20 +340,25 @@ class Go {
         'runtime.wasmWrite': sp => {
           const fd = getInt64(sp + 8)
           const p = getInt64(sp + 16)
-          const n = mem().getInt32(sp + 24, true)
+          const n = this.mem.getInt32(sp + 24, true)
           fs.writeSync(fd, new Uint8Array(this._inst.exports.mem.buffer, p, n))
         },
 
-        // func nanotime() int64
-        'runtime.nanotime': sp => {
+        // func resetMemoryDataView()
+        'runtime.resetMemoryDataView': sp => {
+          this.mem = new DataView(this._inst.exports.mem.buffer)
+        },
+
+        // func nanotime1() int64
+        'runtime.nanotime1': sp => {
           setInt64(sp + 8, (timeOrigin + performance.now()) * 1000000)
         },
 
-        // func walltime() (sec int64, nsec int32)
-        'runtime.walltime': sp => {
+        // func walltime1() (sec int64, nsec int32)
+        'runtime.walltime1': sp => {
           const msec = new Date().getTime()
           setInt64(sp + 8, msec / 1000)
-          mem().setInt32(sp + 16, (msec % 1000) * 1000000, true)
+          this.mem.setInt32(sp + 16, (msec % 1000) * 1000000, true)
         },
 
         // func scheduleTimeoutEvent(delay int64) int32
@@ -279,12 +380,12 @@ class Go {
               getInt64(sp + 8) + 1 // setTimeout has been seen to fire up to 1 millisecond early
             )
           )
-          mem().setInt32(sp + 16, id, true)
+          this.mem.setInt32(sp + 16, id, true)
         },
 
         // func clearTimeoutEvent(id int32)
         'runtime.clearTimeoutEvent': sp => {
-          const id = mem().getInt32(sp + 8, true)
+          const id = this.mem.getInt32(sp + 8, true)
           clearTimeout(this._scheduledTimeouts.get(id))
           this._scheduledTimeouts.delete(id)
         },
@@ -292,6 +393,18 @@ class Go {
         // func getRandomData(r []byte)
         'runtime.getRandomData': sp => {
           crypto.getRandomValues(loadSlice(sp + 8))
+        },
+
+        // func finalizeRef(v ref)
+        'syscall/js.finalizeRef': sp => {
+          const id = this.mem.getUint32(sp + 8, true)
+          this._goRefCounts[id]--
+          if (this._goRefCounts[id] === 0) {
+            const v = this._values[id]
+            this._values[id] = null
+            this._ids.delete(v)
+            this._idPool.push(id)
+          }
         },
 
         // func stringVal(value string) ref
@@ -315,6 +428,11 @@ class Go {
           )
         },
 
+        // func valueDelete(v ref, p string)
+        'syscall/js.valueDelete': sp => {
+          Reflect.deleteProperty(loadValue(sp + 8), loadString(sp + 16))
+        },
+
         // func valueIndex(v ref, i int) ref
         'syscall/js.valueIndex': sp => {
           storeValue(sp + 24, Reflect.get(loadValue(sp + 8), getInt64(sp + 16)))
@@ -334,10 +452,10 @@ class Go {
             const result = Reflect.apply(m, v, args)
             sp = this._inst.exports.getsp() // see comment above
             storeValue(sp + 56, result)
-            mem().setUint8(sp + 64, 1)
+            this.mem.setUint8(sp + 64, 1)
           } catch (err) {
             storeValue(sp + 56, err)
-            mem().setUint8(sp + 64, 0)
+            this.mem.setUint8(sp + 64, 0)
           }
         },
 
@@ -349,10 +467,10 @@ class Go {
             const result = Reflect.apply(v, undefined, args)
             sp = this._inst.exports.getsp() // see comment above
             storeValue(sp + 40, result)
-            mem().setUint8(sp + 48, 1)
+            this.mem.setUint8(sp + 48, 1)
           } catch (err) {
             storeValue(sp + 40, err)
-            mem().setUint8(sp + 48, 0)
+            this.mem.setUint8(sp + 48, 0)
           }
         },
 
@@ -364,10 +482,10 @@ class Go {
             const result = Reflect.construct(v, args)
             sp = this._inst.exports.getsp() // see comment above
             storeValue(sp + 40, result)
-            mem().setUint8(sp + 48, 1)
+            this.mem.setUint8(sp + 48, 1)
           } catch (err) {
             storeValue(sp + 40, err)
-            mem().setUint8(sp + 48, 0)
+            this.mem.setUint8(sp + 48, 0)
           }
         },
 
@@ -391,7 +509,7 @@ class Go {
 
         // func valueInstanceOf(v ref, t ref) bool
         'syscall/js.valueInstanceOf': sp => {
-          mem().setUint8(
+          this.mem.setUint8(
             sp + 24,
             loadValue(sp + 8) instanceof loadValue(sp + 16)
           )
@@ -402,13 +520,13 @@ class Go {
           const dst = loadSlice(sp + 8)
           const src = loadValue(sp + 32)
           if (!(src instanceof Uint8Array)) {
-            mem().setUint8(sp + 48, 0)
+            this.mem.setUint8(sp + 48, 0)
             return
           }
           const toCopy = src.subarray(0, dst.length)
           dst.set(toCopy)
           setInt64(sp + 40, toCopy.length)
-          mem().setUint8(sp + 48, 1)
+          this.mem.setUint8(sp + 48, 1)
         },
 
         // func copyBytesToJS(dst ref, src []byte) (int, bool)
@@ -416,13 +534,13 @@ class Go {
           const dst = loadValue(sp + 8)
           const src = loadSlice(sp + 16)
           if (!(dst instanceof Uint8Array)) {
-            mem().setUint8(sp + 48, 0)
+            this.mem.setUint8(sp + 48, 0)
             return
           }
           const toCopy = src.subarray(0, dst.length)
           dst.set(toCopy)
           setInt64(sp + 40, toCopy.length)
-          mem().setUint8(sp + 48, 1)
+          this.mem.setUint8(sp + 48, 1)
         },
 
         debug: value => {
@@ -434,8 +552,9 @@ class Go {
 
   async run(instance) {
     this._inst = instance
+    this.mem = new DataView(this._inst.exports.mem.buffer)
     this._values = [
-      // TODO: garbage collection
+      // JS values that Go currently has references to, indexed by reference id
       NaN,
       0,
       null,
@@ -444,10 +563,10 @@ class Go {
       global,
       this,
     ]
-    this._refs = new Map()
-    this.exited = false
-
-    const mem = new DataView(this._inst.exports.mem.buffer)
+    this._goRefCounts = [] // number of references that Go has to a JS value, indexed by reference id
+    this._ids = new Map() // mapping from JS values to reference ids
+    this._idPool = [] // unused ids that have been garbage collected
+    this.exited = false // whether the Go program has exited
 
     // Pass command line arguments and environment variables to WebAssembly by writing them to the linear memory.
     let offset = 4096
@@ -455,7 +574,7 @@ class Go {
     const strPtr = str => {
       const ptr = offset
       const bytes = encoder.encode(str + '\0')
-      new Uint8Array(mem.buffer, offset, bytes.length).set(bytes)
+      new Uint8Array(this.mem.buffer, offset, bytes.length).set(bytes)
       offset += bytes.length
       if (offset % 8 !== 0) {
         offset += 8 - (offset % 8)
@@ -469,17 +588,18 @@ class Go {
     this.argv.forEach(arg => {
       argvPtrs.push(strPtr(arg))
     })
+    argvPtrs.push(0)
 
     const keys = Object.keys(this.env).sort()
-    argvPtrs.push(keys.length)
     keys.forEach(key => {
       argvPtrs.push(strPtr(`${key}=${this.env[key]}`))
     })
+    argvPtrs.push(0)
 
     const argv = offset
     argvPtrs.forEach(ptr => {
-      mem.setUint32(offset, ptr, true)
-      mem.setUint32(offset + 4, 0, true)
+      this.mem.setUint32(offset, ptr, true)
+      this.mem.setUint32(offset + 4, 0, true)
       offset += 8
     })
 


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/393
Adjusted `wasm_exec.js` to be compatible with Go 1.14+, which was missing all Go WASM functions in the global context. Unfortunately, we cannot support any Go version below `1.14` now, which I added to the readme.

## How to test:
`yarn test`

## Checklist:

- [x] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
