### PR TITLE
feat: add optional key length parameter

### DIFF
--- a/docs/examples/offchain/1_actorProcess.ts
+++ b/docs/examples/offchain/1_actorProcess.ts
@@ -26,7 +26,7 @@ export async function actorProcess({
   // create claimer either from scratch or from mnemonic input
   const claimer = claimerMnemonic
     ? await Claimer.create()
-    : await Claimer.buildFromMnemonic(mnemonic, claimerMnemonicPw)
+    : await Claimer.buildFromMnemonic(mnemonic, { password: claimerMnemonicPw })
 
   // create attester from (pk, sk) pair
   const attester = new Attester(

--- a/docs/examples/offchain/2_issuanceProcess.ts
+++ b/docs/examples/offchain/2_issuanceProcess.ts
@@ -8,8 +8,9 @@ import Credential from '../../../src/claim/Credential'
 function compareClaims(claim: any, claimFromAtt: any): void {
   const [keys1, values1] = Object.entries(claim)
   const [keys2, values2] = Object.entries(claimFromAtt)
-  const checkKeys = keys1.filter(key => keys2.includes(key)).length === 0
-  const checkValues = values1.filter(val => values2.includes(val)).length === 0
+  const checkKeys = keys1.filter((key) => keys2.includes(key)).length === 0
+  const checkValues =
+    values1.filter((val) => values2.includes(val)).length === 0
   if (!checkKeys || !checkValues) {
     console.error('Original claim and claim from attestation do not match!')
   }

--- a/docs/examples/offchain/3_verificationProcessCombined.ts
+++ b/docs/examples/offchain/3_verificationProcessCombined.ts
@@ -35,7 +35,7 @@ export async function verificationProcessCombined({
     )
   }
   console.group()
-  const attesterPubKeys = attesters.map(attester => attester.publicKey)
+  const attesterPubKeys = attesters.map((attester) => attester.publicKey)
 
   // verifier requests presentation for each credential and combines request by calling `finalise`
   // call requestPresentation for every array index

--- a/docs/examples/onchain/1_actorProcess.ts
+++ b/docs/examples/onchain/1_actorProcess.ts
@@ -31,7 +31,7 @@ export async function actorProcessChain({
   // create claimer either from scratch or from mnemonic input
   const claimer = claimerMnemonic
     ? await Claimer.create()
-    : await Claimer.buildFromMnemonic(mnemonic, claimerMnemonicPw)
+    : await Claimer.buildFromMnemonic(mnemonic, { password: claimerMnemonicPw })
 
   // create attester
   const attester = await AttesterChain.buildFromURI(

--- a/docs/examples/onchain/3_verificationProcessCombined.ts
+++ b/docs/examples/onchain/3_verificationProcessCombined.ts
@@ -37,10 +37,10 @@ export async function verificationProcessCombinedChain({
     )
   }
   console.group()
-  const attesterPubKeys = attesters.map(attester => attester.publicKey)
+  const attesterPubKeys = attesters.map((attester) => attester.publicKey)
   const blockchain = await connect()
   const accumulators = await Promise.all(
-    attesters.map(attester => {
+    attesters.map((attester) => {
       return blockchain.getLatestAccumulator(attester.address)
     })
   )

--- a/go-wasm/pkg/wasm/attester.go
+++ b/go-wasm/pkg/wasm/attester.go
@@ -19,8 +19,16 @@ func GenKeypair(this js.Value, inputs []js.Value) (interface{}, error) {
 	if len(inputs) < 2 {
 		return nil, errors.New("missing inputs")
 	}
+	keyLength := DefaultKeyLength
+	if len(inputs) > 2 && !inputs[2].IsUndefined() {
+		keyLength = inputs[2].Int()
+	}
+	sysParams, success := gabi.DefaultSystemParameters[keyLength]
+	if !success {
+		return nil, errors.New("invalid key length")
+	}
 
-	attester, err := credentials.NewAttester(SysParams, inputs[0].Int(), int64(inputs[1].Int()))
+	attester, err := credentials.NewAttester(sysParams, inputs[0].Int(), int64(inputs[1].Int()))
 	if err != nil {
 		return nil, err
 	}

--- a/go-wasm/pkg/wasm/claimer.go
+++ b/go-wasm/pkg/wasm/claimer.go
@@ -14,7 +14,16 @@ import (
 
 // GenKey creates the private key for the claimer
 func GenKey(this js.Value, inputs []js.Value) (interface{}, error) {
-	claimer, err := credentials.NewClaimer(SysParams)
+	keyLength := DefaultKeyLength
+	if len(inputs) > 0 && !inputs[0].IsUndefined() {
+		keyLength = inputs[0].Int()
+	}
+	sysParams, success := gabi.DefaultSystemParameters[keyLength]
+	if !success {
+		return nil, errors.New("invalid key length")
+	}
+
+	claimer, err := credentials.NewClaimer(sysParams)
 	if err != nil {
 		return nil, err
 	}
@@ -29,7 +38,16 @@ func KeyFromMnemonic(this js.Value, inputs []js.Value) (interface{}, error) {
 	if len(inputs) < 2 {
 		return nil, errors.New("Missing password to generate claimer keys")
 	}
-	claimer, err := credentials.ClaimerFromMnemonic(SysParams, inputs[0].String(), inputs[1].String())
+	keyLength := DefaultKeyLength
+	if len(inputs) > 2 && !inputs[2].IsUndefined() {
+		keyLength = inputs[2].Int()
+	}
+	sysParams, success := gabi.DefaultSystemParameters[keyLength]
+	if !success {
+		return nil, errors.New("invalid key length")
+	}
+
+	claimer, err := credentials.ClaimerFromMnemonic(sysParams, inputs[0].String(), inputs[1].String())
 	if err != nil {
 		return nil, err
 	}

--- a/go-wasm/pkg/wasm/helper.go
+++ b/go-wasm/pkg/wasm/helper.go
@@ -6,18 +6,13 @@ import (
 	"encoding/json"
 	"syscall/js"
 	"time"
-
-	"github.com/privacybydesign/gabi"
 )
 
 // KeyLength sets the length of the used keys. Possible values are 1024, 2048, 4096
 const (
-	KeyLength  = 1024
 	TimeFormat = time.RFC3339Nano
+	DefaultKeyLength = 1024
 )
-
-// SysParams are the currently used system parameters for the cryptographic primitives
-var SysParams, _ = gabi.DefaultSystemParameters[KeyLength]
 
 // GoFunction is a function which can be transform it into a JSFunction
 type GoFunction func(js.Value, []js.Value) (interface{}, error)

--- a/go-wasm/pkg/wasm/verifier.go
+++ b/go-wasm/pkg/wasm/verifier.go
@@ -22,6 +22,15 @@ func RequestPresentation(this js.Value, inputs []js.Value) (interface{}, error) 
 	if len(inputs) < 3 {
 		return nil, errors.New("missing inputs")
 	}
+	keyLength := DefaultKeyLength
+	if len(inputs) > 4 && !inputs[3].IsUndefined() {
+		keyLength = inputs[3].Int()
+	}
+	sysParams, success := gabi.DefaultSystemParameters[keyLength]
+	if !success {
+		return nil, errors.New("invalid key length")
+	}
+
 	var requestedAttributes []string
 	if err := json.Unmarshal([]byte(inputs[2].String()), &requestedAttributes); err != nil {
 		return nil, err
@@ -30,7 +39,7 @@ func RequestPresentation(this js.Value, inputs []js.Value) (interface{}, error) 
 	if err != nil {
 		return nil, err
 	}
-	session, msg := credentials.RequestPresentation(SysParams, requestedAttributes, inputs[0].Bool(), updateAfter)
+	session, msg := credentials.RequestPresentation(sysParams, requestedAttributes, inputs[0].Bool(), updateAfter)
 
 	return map[string]interface{}{
 		"session": session,
@@ -42,7 +51,14 @@ func RequestCombinedPresentation(this js.Value, inputs []js.Value) (interface{},
 	if len(inputs) < 1 {
 		return nil, errors.New("missing inputs")
 	}
-
+	keyLength := DefaultKeyLength
+	if len(inputs) > 1 && !inputs[1].IsUndefined() {
+		keyLength = inputs[1].Int()
+	}
+	sysParams, success := gabi.DefaultSystemParameters[keyLength]
+	if !success {
+		return nil, errors.New("invalid key length")
+	}
 	// first two inputs are check-revocation-flag and minimum required revocation index
 	var sessionArgs []credentials.PartialPresentationRequest
 
@@ -50,7 +66,7 @@ func RequestCombinedPresentation(this js.Value, inputs []js.Value) (interface{},
 		return nil, err
 	}
 
-	session, msg := credentials.RequestCombinedPresentation(SysParams, sessionArgs)
+	session, msg := credentials.RequestCombinedPresentation(sysParams, sessionArgs)
 
 	return map[string]interface{}{
 		"session": session,

--- a/src/attestation/Attester.chain.ts
+++ b/src/attestation/Attester.chain.ts
@@ -44,18 +44,21 @@ export default class AttesterChain extends Attester implements IAttesterChain {
    *
    * @param validityDuration The duration in days for which the public key will be valid.
    * @param maxAttributes The maximum number of attributes that can be signed with the generated private key.
+   * @param keyLength The key length of the new key pair. Note that this key will only support credentials and claimer with the same key length.
    * @param keypairType The signature scheme used in the keyring pair, either 'sr25519' or 'ed25519'.
    * @returns A [[AttesterChain]] instance including a chain address and a public and private key pair.
    */
   public static async create(
     validityDuration?: number,
     maxAttributes = 70,
+    keyLength: 1024 | 2048 | 4096 = 1024,
     keypairType: KeypairType = 'sr25519'
   ): Promise<AttesterChain> {
     const durationInNanoSecs = daysToNanoSecs(validityDuration || 365)
     const { publicKey, privateKey } = await super.genKeyPair(
       durationInNanoSecs,
-      maxAttributes
+      maxAttributes,
+      keyLength
     )
     const mnemonic = this.generateMnemonic()
     return this.buildFromMnemonic(publicKey, privateKey, mnemonic, keypairType)

--- a/src/attestation/Attester.chain.ts
+++ b/src/attestation/Attester.chain.ts
@@ -16,6 +16,7 @@ import {
   AttesterPublicKey,
   IAttesterChain,
   AttesterPrivateKey,
+  KeyLength,
 } from '../types/Attestation'
 import connect from '../blockchainApiConnection/BlockchainApiConnection'
 import Accumulator from './Accumulator'
@@ -51,7 +52,7 @@ export default class AttesterChain extends Attester implements IAttesterChain {
   public static async create(
     validityDuration?: number,
     maxAttributes = 70,
-    keyLength: 1024 | 2048 | 4096 = 1024,
+    keyLength: KeyLength = 1024,
     keypairType: KeypairType = 'sr25519'
   ): Promise<AttesterChain> {
     const durationInNanoSecs = daysToNanoSecs(validityDuration || 365)

--- a/src/attestation/Attester.chain.ts
+++ b/src/attestation/Attester.chain.ts
@@ -10,16 +10,20 @@ import {
 } from '@polkadot/util-crypto'
 import { KeypairType } from '@polkadot/util-crypto/types'
 import { u8aToHex } from '@polkadot/util'
-import Attester, { daysToNanoSecs } from './Attester'
+import Attester, { KeyGenOptions } from './Attester'
 import {
   Witness,
   AttesterPublicKey,
   IAttesterChain,
   AttesterPrivateKey,
-  KeyLength,
 } from '../types/Attestation'
 import connect from '../blockchainApiConnection/BlockchainApiConnection'
 import Accumulator from './Accumulator'
+import { DEFAULT_KEY_TYPE } from '../types/Chain'
+
+export type ChainKeyGenOptions = KeyGenOptions & {
+  keypairType?: KeypairType
+}
 
 /**
  * The AttesterChain extends an [[Attester]]'s creation process and functionality to on-chain compatibility.
@@ -43,26 +47,24 @@ export default class AttesterChain extends Attester implements IAttesterChain {
   /**
    * Generates a new key pair and returns a new [[AttesterChain]].
    *
-   * @param validityDuration The duration in days for which the public key will be valid.
-   * @param maxAttributes The maximum number of attributes that can be signed with the generated private key.
-   * @param keyLength The key length of the new key pair. Note that this key will only support credentials and claimer with the same key length.
-   * @param keypairType The signature scheme used in the keyring pair, either 'sr25519' or 'ed25519'.
+   * @param options An optional object containing options for the key generation.
+   * @param options.validityDuration The duration in days for which the public key will be valid.
+   * @param options.maxAttributes The maximum number of attributes that can be signed with the generated private key.
+   * @param options.keyLength The key length of the new key pair. Note that this key will only support credentials and claimer with the same key length.
+   * @param options.keypairType The signature scheme used in the keyring pair, either 'sr25519' or 'ed25519'.
    * @returns A [[AttesterChain]] instance including a chain address and a public and private key pair.
    */
   public static async create(
-    validityDuration?: number,
-    maxAttributes = 70,
-    keyLength: KeyLength = 1024,
-    keypairType: KeypairType = 'sr25519'
+    options: ChainKeyGenOptions = {}
   ): Promise<AttesterChain> {
-    const durationInNanoSecs = daysToNanoSecs(validityDuration || 365)
-    const { publicKey, privateKey } = await super.genKeyPair(
-      durationInNanoSecs,
-      maxAttributes,
-      keyLength
-    )
+    const { publicKey, privateKey } = await super.genKeyPair(options)
     const mnemonic = this.generateMnemonic()
-    return this.buildFromMnemonic(publicKey, privateKey, mnemonic, keypairType)
+    return this.buildFromMnemonic(
+      publicKey,
+      privateKey,
+      mnemonic,
+      options.keypairType || DEFAULT_KEY_TYPE
+    )
   }
 
   /**

--- a/src/attestation/Attester.spec.ts
+++ b/src/attestation/Attester.spec.ts
@@ -91,7 +91,7 @@ describe('Test attester', () => {
         keypair.publicKey
       )
       await expect(
-        AttesterChain.create(1, 10, 'ed25519')
+        AttesterChain.create(1, 10, 1024, 'ed25519')
       ).resolves.toHaveProperty('privateKey', keypair.privateKey)
       await expect(AttesterChain.create()).resolves.toHaveProperty(
         'publicKey',

--- a/src/attestation/Attester.spec.ts
+++ b/src/attestation/Attester.spec.ts
@@ -78,20 +78,32 @@ describe('Test attester', () => {
     })
     it('Should generate dummy key pair', async () => {
       ;(goWasmExec as any) = jest.fn(async () => keypair)
-      await expect(Attester.genKeyPair(1, 10)).resolves.toEqual(keypair)
+      await expect(
+        Attester.genKeyPair({
+          validityDuration: 1,
+          maxAttributes: 10,
+        })
+      ).resolves.toEqual(keypair)
       await expect(Attester.genKeyPair()).resolves.toEqual(keypair)
     })
     it('Should create attester', async () => {
-      await expect(Attester.create(1, 10)).resolves.toHaveProperty(
-        'privateKey',
-        keypair.privateKey
-      )
+      await expect(
+        Attester.create({
+          validityDuration: 1,
+          maxAttributes: 10,
+        })
+      ).resolves.toHaveProperty('privateKey', keypair.privateKey)
       await expect(Attester.create()).resolves.toHaveProperty(
         'publicKey',
         keypair.publicKey
       )
       await expect(
-        AttesterChain.create(1, 10, 1024, 'ed25519')
+        AttesterChain.create({
+          validityDuration: 1,
+          maxAttributes: 10,
+          keyLength: 1024,
+          keypairType: 'ed25519',
+        })
       ).resolves.toHaveProperty('privateKey', keypair.privateKey)
       await expect(AttesterChain.create()).resolves.toHaveProperty(
         'publicKey',

--- a/src/attestation/Attester.ts
+++ b/src/attestation/Attester.ts
@@ -41,7 +41,8 @@ export default class Attester implements IAttester {
    */
   public static async genKeyPair(
     validityDuration?: number,
-    maxAttributes = 70
+    maxAttributes = 70,
+    keyLength: 1024 | 2048 | 4096 = 1024
   ): Promise<{
     privateKey: AttesterPrivateKey
     publicKey: AttesterPublicKey
@@ -50,7 +51,7 @@ export default class Attester implements IAttester {
     const { privateKey, publicKey } = await goWasmExec<{
       privateKey: string
       publicKey: string
-    }>(WasmHooks.genKeypair, [maxAttributes, durationInNanoSecs])
+    }>(WasmHooks.genKeypair, [maxAttributes, durationInNanoSecs, keyLength])
     return {
       privateKey: new AttesterPrivateKey(privateKey),
       publicKey: new AttesterPublicKey(publicKey),

--- a/src/attestation/Attester.ts
+++ b/src/attestation/Attester.ts
@@ -37,6 +37,7 @@ export default class Attester implements IAttester {
    *
    * @param validityDuration The duration in days for which the public key will be valid.
    * @param maxAttributes The maximum number of attributes that can be signed with the generated private key.
+   * @param keyLength The key length of the new key pair. Note that this key will only support credentials and claimer with the same key length.
    * @returns A newly generated key pair.
    */
   public static async genKeyPair(
@@ -63,16 +64,19 @@ export default class Attester implements IAttester {
    *
    * @param validityDuration The duration in days for which the public key will be valid.
    * @param maxAttributes The maximal number of attributes that can be signed with the generated private key.
+   * @param keyLength The key length of the new key pair. Note that this key will only support credentials and claimer with the same key length.
    * @returns A new [[Attester]].
    */
   public static async create(
     validityDuration?: number,
-    maxAttributes = 70
+    maxAttributes = 70,
+    keyLength: 1024 | 2048 | 4096 = 1024
   ): Promise<Attester> {
     const durationInNanoSecs = daysToNanoSecs(validityDuration || 365)
     const { publicKey, privateKey } = await this.genKeyPair(
       durationInNanoSecs,
-      maxAttributes
+      maxAttributes,
+      keyLength
     )
     return new Attester(publicKey, privateKey)
   }

--- a/src/attestation/Attester.ts
+++ b/src/attestation/Attester.ts
@@ -14,7 +14,16 @@ import IAttester, {
   AttesterPublicKey,
   AttesterPrivateKey,
   KeyLength,
+  DEFAULT_MAX_ATTRIBUTES,
+  DEFAULT_VALIDITY_DURATION,
+  DEFAULT_KEY_LENGTH,
 } from '../types/Attestation'
+
+export type KeyGenOptions = {
+  validityDuration?: number
+  maxAttributes?: number
+  keyLength?: KeyLength
+}
 
 /**
  * Converts days to nano seconds.
@@ -36,24 +45,31 @@ export default class Attester implements IAttester {
   /**
    * Generates a new key pair.
    *
-   * @param validityDuration The duration in days for which the public key will be valid.
-   * @param maxAttributes The maximum number of attributes that can be signed with the generated private key.
-   * @param keyLength The key length of the new key pair. Note that this key will only support credentials and claimer with the same key length.
+   * @param options An optional object containing options for the key generation.
+   * @param options.validityDuration The duration in days for which the public key will be valid.
+   * @param options.maxAttributes The maximum number of attributes that can be signed with the generated private key.
+   * @param options.keyLength The key length of the new key pair. Note that this key will only support credentials and claimer with the same key length.
    * @returns A newly generated key pair.
    */
-  public static async genKeyPair(
-    validityDuration?: number,
-    maxAttributes = 70,
-    keyLength: KeyLength = 1024
-  ): Promise<{
+  public static async genKeyPair({
+    validityDuration,
+    maxAttributes,
+    keyLength,
+  }: KeyGenOptions = {}): Promise<{
     privateKey: AttesterPrivateKey
     publicKey: AttesterPublicKey
   }> {
-    const durationInNanoSecs = daysToNanoSecs(validityDuration || 365)
+    const durationInNanoSecs = daysToNanoSecs(
+      validityDuration || DEFAULT_VALIDITY_DURATION
+    )
     const { privateKey, publicKey } = await goWasmExec<{
       privateKey: string
       publicKey: string
-    }>(WasmHooks.genKeypair, [maxAttributes, durationInNanoSecs, keyLength])
+    }>(WasmHooks.genKeypair, [
+      maxAttributes || DEFAULT_MAX_ATTRIBUTES,
+      durationInNanoSecs,
+      keyLength || DEFAULT_KEY_LENGTH,
+    ])
     return {
       privateKey: new AttesterPrivateKey(privateKey),
       publicKey: new AttesterPublicKey(publicKey),
@@ -63,22 +79,14 @@ export default class Attester implements IAttester {
   /**
    * Generates a new key pair and returns a new [[Attester]].
    *
-   * @param validityDuration The duration in days for which the public key will be valid.
-   * @param maxAttributes The maximal number of attributes that can be signed with the generated private key.
-   * @param keyLength The key length of the new key pair. Note that this key will only support credentials and claimer with the same key length.
+   * @param options An optional object containing options for the key generation.
+   * @param options.validityDuration The duration in days for which the public key will be valid.
+   * @param options.maxAttributes The maximal number of attributes that can be signed with the generated private key.
+   * @param options.keyLength The key length of the new key pair. Note that this key will only support credentials and claimer with the same key length.
    * @returns A new [[Attester]].
    */
-  public static async create(
-    validityDuration?: number,
-    maxAttributes = 70,
-    keyLength: KeyLength = 1024
-  ): Promise<Attester> {
-    const durationInNanoSecs = daysToNanoSecs(validityDuration || 365)
-    const { publicKey, privateKey } = await this.genKeyPair(
-      durationInNanoSecs,
-      maxAttributes,
-      keyLength
-    )
+  public static async create(options: KeyGenOptions = {}): Promise<Attester> {
+    const { publicKey, privateKey } = await this.genKeyPair(options)
     return new Attester(publicKey, privateKey)
   }
 

--- a/src/attestation/Attester.ts
+++ b/src/attestation/Attester.ts
@@ -13,6 +13,7 @@ import IAttester, {
   Attestation,
   AttesterPublicKey,
   AttesterPrivateKey,
+  KeyLength,
 } from '../types/Attestation'
 
 /**
@@ -43,7 +44,7 @@ export default class Attester implements IAttester {
   public static async genKeyPair(
     validityDuration?: number,
     maxAttributes = 70,
-    keyLength: 1024 | 2048 | 4096 = 1024
+    keyLength: KeyLength = 1024
   ): Promise<{
     privateKey: AttesterPrivateKey
     publicKey: AttesterPublicKey
@@ -70,7 +71,7 @@ export default class Attester implements IAttester {
   public static async create(
     validityDuration?: number,
     maxAttributes = 70,
-    keyLength: 1024 | 2048 | 4096 = 1024
+    keyLength: KeyLength = 1024
   ): Promise<Attester> {
     const durationInNanoSecs = daysToNanoSecs(validityDuration || 365)
     const { publicKey, privateKey } = await this.genKeyPair(

--- a/src/claim/Claimer.spec.ts
+++ b/src/claim/Claimer.spec.ts
@@ -54,7 +54,9 @@ describe('Test claimer creation', () => {
     expect(claimerWithoutPass).not.toStrictEqual(claimer)
     const claimerWithPass = await Claimer.buildFromMnemonic(
       mnemonicGenerate(),
-      'password'
+      {
+        password: 'password',
+      }
     )
     expect(claimerWithPass).toHaveProperty('secret')
     expect(claimer).toHaveProperty('secret')
@@ -68,7 +70,9 @@ describe('Test claimer creation', () => {
       '{"MasterSecret":"HdWjkfn17XNA/01FE6q5zORPlJel5+2F/YGIdrbrQC4="}'
     )
     expect(claimerWithoutPass).not.toStrictEqual(claimer)
-    const claimerWithPass = await Claimer.buildFromMnemonic('', 'password')
+    const claimerWithPass = await Claimer.buildFromMnemonic('', {
+      password: 'password',
+    })
     expect(claimerWithPass).toHaveProperty(
       'secret',
       '{"MasterSecret":"Ugc7cbbFMn0UzRGkxgahlb6GxLohyWp2/6G2L6GrCVo="}'
@@ -87,7 +91,7 @@ describe('Test claimer creation', () => {
     expect(claimerWithoutPass).not.toStrictEqual(claimer)
     const claimerWithPass = await Claimer.buildFromMnemonic(
       'scissors purse again yellow cabbage fat alpha come snack ripple jacket broken',
-      'password'
+      { password: 'password' }
     )
     expect(claimerWithPass).toHaveProperty(
       'secret',

--- a/src/claim/Claimer.ts
+++ b/src/claim/Claimer.ts
@@ -12,6 +12,7 @@ import {
   Attestation,
   AttesterPublicKey,
   KeyLength,
+  DEFAULT_KEY_LENGTH,
 } from '../types/Attestation'
 import {
   CombinedPresentationRequest,
@@ -47,20 +48,26 @@ export default class Claimer implements IClaimer {
    * Generates a claimer using the provided mnemonic.
    *
    * @param mnemonic The mnemonic which is used to generate the key.
-   * @param password The password which is used to generate the key.
-   * @param keyLength The key length of the new secret. Note that this secret will only support credentials and attester with the same key length.
+   * @param options An optional object containing options for the key generation.
+   * @param options.password The password which is used to generate the key.
+   * @param options.keyLength The key length of the new secret. Note that this secret will only support credentials and attester with the same key length.
    * @returns A new claimer.
    */
   public static async buildFromMnemonic(
     mnemonic: string,
-    password = '',
-    keyLength: KeyLength = 1024
+    {
+      password,
+      keyLength,
+    }: {
+      password?: string
+      keyLength?: KeyLength
+    } = {}
   ): Promise<Claimer> {
     // secret's structure unmarshalled is { MasterSecret: string }
     const secret = await goWasmExec<string>(WasmHooks.keyFromMnemonic, [
       mnemonic,
-      password,
-      keyLength,
+      password || '',
+      keyLength || DEFAULT_KEY_LENGTH,
     ])
     return new this(secret)
   }

--- a/src/claim/Claimer.ts
+++ b/src/claim/Claimer.ts
@@ -47,7 +47,7 @@ export default class Claimer implements IClaimer {
    *
    * @param mnemonic The mnemonic which is used to generate the key.
    * @param password The password which is used to generate the key.
-   * @param keyLength The key length .
+   * @param keyLength The key length of the new secret. Note that this secret will only support credentials and attester with the same key length.
    * @returns A new claimer.
    */
   public static async buildFromMnemonic(

--- a/src/claim/Claimer.ts
+++ b/src/claim/Claimer.ts
@@ -11,6 +11,7 @@ import {
   InitiateAttestationRequest,
   Attestation,
   AttesterPublicKey,
+  KeyLength,
 } from '../types/Attestation'
 import {
   CombinedPresentationRequest,
@@ -53,7 +54,7 @@ export default class Claimer implements IClaimer {
   public static async buildFromMnemonic(
     mnemonic: string,
     password = '',
-    keyLength = 1024
+    keyLength: KeyLength = 1024
   ): Promise<Claimer> {
     // secret's structure unmarshalled is { MasterSecret: string }
     const secret = await goWasmExec<string>(WasmHooks.keyFromMnemonic, [

--- a/src/claim/Claimer.ts
+++ b/src/claim/Claimer.ts
@@ -47,16 +47,19 @@ export default class Claimer implements IClaimer {
    *
    * @param mnemonic The mnemonic which is used to generate the key.
    * @param password The password which is used to generate the key.
+   * @param keyLength The key length .
    * @returns A new claimer.
    */
   public static async buildFromMnemonic(
     mnemonic: string,
-    password = ''
+    password = '',
+    keyLength = 1024
   ): Promise<Claimer> {
     // secret's structure unmarshalled is { MasterSecret: string }
     const secret = await goWasmExec<string>(WasmHooks.keyFromMnemonic, [
       mnemonic,
       password,
+      keyLength,
     ])
     return new this(secret)
   }

--- a/src/types/Attestation.ts
+++ b/src/types/Attestation.ts
@@ -2,6 +2,8 @@
 /* eslint-disable-next-line max-classes-per-file */
 import Accumulator from '../attestation/Accumulator'
 
+export type KeyLength = 1024 | 2048 | 4096
+
 export interface IGabiMsgSession {
   message: string
   session: string

--- a/src/types/Attestation.ts
+++ b/src/types/Attestation.ts
@@ -3,6 +3,9 @@
 import Accumulator from '../attestation/Accumulator'
 
 export type KeyLength = 1024 | 2048 | 4096
+export const DEFAULT_MAX_ATTRIBUTES = 70
+export const DEFAULT_VALIDITY_DURATION = 365
+export const DEFAULT_KEY_LENGTH = 1024
 
 export interface IGabiMsgSession {
   message: string

--- a/src/types/Chain.ts
+++ b/src/types/Chain.ts
@@ -9,6 +9,11 @@ import Accumulator from '../attestation/Accumulator'
  */
 export type PgabiModName = 'portablegabi' | 'portablegabiPallet' | string
 
+/**
+ * The default key type for the attester identities.
+ */
+export const DEFAULT_KEY_TYPE = 'sr25519'
+
 export interface IPortablegabiApi<T extends PgabiModName> {
   query: {
     [K in T]: {

--- a/src/types/Verification.ts
+++ b/src/types/Verification.ts
@@ -4,6 +4,7 @@
 export interface IPresentationRequest {
   requestedAttributes: string[]
   reqUpdatedAfter?: Date
+  keyLength?: 1024 | 2048 | 4096
 }
 
 export interface IVerifiedPresentation {

--- a/src/types/Verification.ts
+++ b/src/types/Verification.ts
@@ -1,10 +1,12 @@
 /* eslint-disable @typescript-eslint/ban-ts-ignore */
 /* eslint-disable max-classes-per-file */
 
+import { KeyLength } from './Attestation'
+
 export interface IPresentationRequest {
   requestedAttributes: string[]
   reqUpdatedAfter?: Date
-  keyLength?: 1024 | 2048 | 4096
+  keyLength?: KeyLength
 }
 
 export interface IVerifiedPresentation {

--- a/src/verification/Verifier.ts
+++ b/src/verification/Verifier.ts
@@ -31,23 +31,31 @@ export default class Verifier {
   public static async requestPresentation({
     requestedAttributes,
     reqUpdatedAfter,
+    keyLength,
   }: IPresentationRequest): Promise<{
     message: PresentationRequest
     session: VerificationSession
   }> {
-    let args: [boolean, string, string]
+    // since we are using a destructed object as parameter, we don't have default parameter
+    let kl = keyLength
+    if (typeof kl === 'undefined') {
+      kl = 1024
+    }
+    let args: [boolean, string, string, 1024 | 2048 | 4096]
     if (typeof reqUpdatedAfter === 'undefined') {
       args = [
         false,
         // date will be ignored, we won't check for a revocation proof
         new Date().toISOString(),
         JSON.stringify(requestedAttributes),
+        kl,
       ]
     } else {
       args = [
         true,
         reqUpdatedAfter.toISOString(),
         JSON.stringify(requestedAttributes),
+        kl,
       ]
     }
     const { message, session } = await goWasmExec<IGabiMsgSession>(

--- a/src/verification/Verifier.ts
+++ b/src/verification/Verifier.ts
@@ -13,7 +13,11 @@ import {
   CombinedVerificationSession,
   CombinedPresentationRequest,
 } from '../types/Verification'
-import { IGabiMsgSession, AttesterPublicKey } from '../types/Attestation'
+import {
+  IGabiMsgSession,
+  AttesterPublicKey,
+  KeyLength,
+} from '../types/Attestation'
 import { Presentation, CombinedPresentation } from '../types/Claim'
 
 /**
@@ -26,6 +30,7 @@ export default class Verifier {
    * @param p The parameter object.
    * @param p.requestedAttributes The attributes that need to be disclosed for the [[Verifier]] in order to verify the [[Credential]].
    * @param p.reqUpdatedAfter The minimum [[Accumulator]] timestamp on which the [[Credential]] needs to be updated.
+   * @param p.keyLength The key length of the new key pair. Note that this key will only support credentials and claimer with the same key length.
    * @returns A session and a message object. The message should be sent to the [[Claimer]] and used in [[buildPresentation]]. The session should be kept private and used in [[verifyPresentation]].
    */
   public static async requestPresentation({
@@ -41,7 +46,7 @@ export default class Verifier {
     if (typeof kl === 'undefined') {
       kl = 1024
     }
-    let args: [boolean, string, string, 1024 | 2048 | 4096]
+    let args: [boolean, string, string, KeyLength]
     if (typeof reqUpdatedAfter === 'undefined') {
       args = [
         false,


### PR DESCRIPTION
# fix KILTprotocol/ticket/issues/289

Added an optional key length parameter to the GO-WASM API. This should not change the API since the parameter is only optional and for the GO code.

## How to test:

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
