### PR TITLE
Improve WASM closing

### DIFF
--- a/docs/examples/exampleCombined.chain.ts
+++ b/docs/examples/exampleCombined.chain.ts
@@ -109,7 +109,7 @@ async function completeProcessCombined({
 async function completeProcessCombinedExamples(): Promise<void> {
   // connect to chain
   const blockchain = await connect({
-    pgabiModName: 'portablegabiPallet',
+    pgabiModName: 'portablegabi',
   })
   console.log('Connected to chain')
   // we accept every accumulator when requiring past in reqUpdatedAfter

--- a/docs/examples/exampleCombined.chain.ts
+++ b/docs/examples/exampleCombined.chain.ts
@@ -7,6 +7,7 @@ import { testEnv1, testEnv2, mnemonic } from './exampleConfig'
 import actorProcessChain from './onchain/1_actorProcess'
 import issuanceProcess from './offchain/2_issuanceProcess'
 import verificationProcessCombinedChain from './onchain/3_verificationProcessCombined'
+import { goWasmClose } from '../../src/wasm/wasm_exec_wrapper'
 
 const {
   pubKey: pubKey1,
@@ -170,7 +171,7 @@ async function completeProcessCombinedExamples(): Promise<void> {
   })
 
   // disconnect from chain
-  await disconnect().finally(() => process.exit())
+  return disconnect().finally(() => goWasmClose())
 }
 
 completeProcessCombinedExamples()

--- a/docs/examples/exampleCombined.ts
+++ b/docs/examples/exampleCombined.ts
@@ -113,7 +113,7 @@ async function completeProcessCombinedExamples(): Promise<void> {
   await completeProcessCombined(true, true, [undefined, past])
 
   // close wasm
-  return goWasmClose().finally(() => process.exit())
+  return goWasmClose()
 }
 
 completeProcessCombinedExamples()

--- a/docs/examples/exampleSingle.chain.ts
+++ b/docs/examples/exampleSingle.chain.ts
@@ -128,7 +128,7 @@ async function completeProcessSingleExamples(): Promise<void> {
   })
 
   // disconnect from chain
-  await disconnect().finally(() => goWasmClose())
+  return disconnect().finally(() => goWasmClose())
 }
 
 completeProcessSingleExamples()

--- a/docs/examples/exampleSingle.chain.ts
+++ b/docs/examples/exampleSingle.chain.ts
@@ -7,6 +7,7 @@ import { testEnv1, mnemonic } from './exampleConfig'
 import actorProcessChain from './onchain/1_actorProcess'
 import verificationProcessSingleChain from './onchain/3_verificationProcessSingle'
 import issuanceProcess from './offchain/2_issuanceProcess'
+import { goWasmClose } from '../../src/wasm/wasm_exec_wrapper'
 
 const { pubKey, privKey, disclosedAttributes, claim } = testEnv1
 
@@ -79,7 +80,7 @@ async function completeProcessSingle({
 // all calls of completeProcessSingle should return true
 async function completeProcessSingleExamples(): Promise<void> {
   // connect to chain
-  const blockchain = await connect({ pgabiModName: 'portablegabiPallet' })
+  const blockchain = await connect({ pgabiModName: 'portablegabi' })
   console.log('Connected to chain')
   // we accept every accumulator when requiring past in reqUpdatedAfter
   const past = new Date(0)
@@ -127,7 +128,7 @@ async function completeProcessSingleExamples(): Promise<void> {
   })
 
   // disconnect from chain
-  await disconnect().finally(() => process.exit())
+  await disconnect().finally(() => goWasmClose())
 }
 
 completeProcessSingleExamples()

--- a/docs/examples/exampleSingle.ts
+++ b/docs/examples/exampleSingle.ts
@@ -80,7 +80,7 @@ async function completeProcessSingleExamples(): Promise<void> {
   await completeProcessSingle(true, true, undefined)
 
   // close wasm
-  return goWasmClose().finally(() => process.exit())
+  return goWasmClose()
 }
 
 completeProcessSingleExamples()

--- a/docs/examples/onchain/1_actorProcess.ts
+++ b/docs/examples/onchain/1_actorProcess.ts
@@ -37,7 +37,8 @@ export async function actorProcessChain({
   const attester = await AttesterChain.buildFromURI(
     new AttesterPublicKey(attesterPubKey),
     new AttesterPrivateKey(attesterPrivKey),
-    attesterURI
+    attesterURI,
+    'ed25519'
   )
 
   // get accumulator from chain

--- a/go-wasm/main.go
+++ b/go-wasm/main.go
@@ -9,12 +9,21 @@ import (
 	"github.com/KILTprotocol/portablegabi/go-wasm/pkg/wasm"
 )
 
+var c chan bool
+
+func init() {
+	c = make(chan bool)
+}
+
+func CloseWasm(js.Value, []js.Value) interface{} {
+	close(c)
+	return nil
+}
+
 func main() {
 
 	// expose all methods to the js environment. Use callbacker to transform the
 	// return style methods to callback style methods.
-	c := make(chan bool)
-
 	methods := make(map[string]js.Func)
 	methods["genKeypair"] = js.FuncOf(wasm.Callbacker(wasm.GenKeypair))
 	methods["createAccumulator"] = js.FuncOf(wasm.Callbacker(wasm.CreateAccumulator))
@@ -38,6 +47,7 @@ func main() {
 
 	methods["getAccumulatorIndex"] = js.FuncOf(wasm.Callbacker(wasm.GetAccumulatorIndex))
 	methods["getAccumulatorTimestamp"] = js.FuncOf(wasm.Callbacker(wasm.GetAccumulatorTimestamp))
+	methods["closeWasm"] = js.FuncOf(CloseWasm)
 
 	for k, v := range methods {
 		js.Global().Set(k, v)

--- a/src/testSetup/jest.teardown.js
+++ b/src/testSetup/jest.teardown.js
@@ -2,5 +2,5 @@
 const { goWasmClose } = require('../wasm/wasm_exec_wrapper')
 
 module.exports = async function teardown() {
-  return goWasmClose().finally(() => process.exit())
+  return goWasmClose()
 }

--- a/src/wasm/WasmHooks.ts
+++ b/src/wasm/WasmHooks.ts
@@ -1,4 +1,7 @@
 enum WasmHooks {
+  // misc
+  closeWasm = 'closeWasm',
+
   // claimer methods
   genKey = 'genKey',
   keyFromMnemonic = 'keyFromMnemonic',

--- a/src/wasm/wasm_exec_wrapper.spec.ts
+++ b/src/wasm/wasm_exec_wrapper.spec.ts
@@ -9,7 +9,7 @@ describe('Test WASM wrapper', () => {
     x =>
       x !== WasmHooks.genKeypair && // # 1 takes too much time
       x !== WasmHooks.genKey && // #2 works w/o input
-      x !== WasmHooks.closeWasm // #3 TODO: ,
+      x !== WasmHooks.closeWasm // #3 needs custom handling
   )
   beforeEach(() => {
     spy = {

--- a/src/wasm/wasm_exec_wrapper.spec.ts
+++ b/src/wasm/wasm_exec_wrapper.spec.ts
@@ -6,7 +6,7 @@ import { WasmError } from './wasm_exec'
 describe('Test WASM wrapper', () => {
   let spy: Spy<''>
   const hooksArr: string[] = Object.keys(WasmHooks).filter(
-    x =>
+    (x) =>
       x !== WasmHooks.genKeypair && // # 1 takes too much time
       x !== WasmHooks.genKey && // #2 works w/o input
       x !== WasmHooks.closeWasm // #3 needs custom handling
@@ -28,7 +28,7 @@ describe('Test WASM wrapper', () => {
   })
   it.each(hooksArr)(
     'Should throw calling %s without input',
-    async wasmHook =>
+    async (wasmHook) =>
       expect(goWasmExec(wasmHook as WasmHooks)).rejects.toThrow(WasmError),
     5000
   )
@@ -36,7 +36,7 @@ describe('Test WASM wrapper', () => {
     return expect(goWasmExec(WasmHooks.genKey)).resolves.toBeDefined()
   }, 5000)
 })
-it('Should exit on process when closing WASM with non empty event queue', async done => {
+it('Should exit on process when closing WASM with non empty event queue', async (done) => {
   jest.spyOn(process, 'exit').mockImplementation()
   const spy = {
     exit: jest.spyOn(process, 'exit').mockImplementation(),

--- a/src/wasm/wasm_exec_wrapper.spec.ts
+++ b/src/wasm/wasm_exec_wrapper.spec.ts
@@ -1,4 +1,4 @@
-import goWasmExec, { goWasmInit, goWasmClose } from './wasm_exec_wrapper'
+import goWasmExec, { goWasmClose } from './wasm_exec_wrapper'
 import WasmHooks from './WasmHooks'
 import { Spy } from '../testSetup/testTypes'
 import { WasmError } from './wasm_exec'
@@ -6,7 +6,10 @@ import { WasmError } from './wasm_exec'
 describe('Test WASM wrapper', () => {
   let spy: Spy<''>
   const hooksArr: string[] = Object.keys(WasmHooks).filter(
-    (x) => x !== WasmHooks.genKeypair && x !== WasmHooks.genKey // # 1 takes too much time, #2 works w/o input
+    x =>
+      x !== WasmHooks.genKeypair && // # 1 takes too much time
+      x !== WasmHooks.genKey && // #2 works w/o input
+      x !== WasmHooks.closeWasm // #3 TODO: ,
   )
   beforeEach(() => {
     spy = {
@@ -25,18 +28,28 @@ describe('Test WASM wrapper', () => {
   })
   it.each(hooksArr)(
     'Should throw calling %s without input',
-    async (wasmHook) =>
+    async wasmHook =>
       expect(goWasmExec(wasmHook as WasmHooks)).rejects.toThrow(WasmError),
     5000
   )
   it('Should not throw calling genKey without input', async () => {
-    await goWasmExec(WasmHooks.genKey)
-  })
-  it('Checks proper instantiation + closing of WASM', async () => {
-    const GoInstance = await goWasmInit()
-    const wasmExitSpy: jest.SpyInstance = jest.spyOn(GoInstance, 'exit')
-    expect(GoInstance).toBeDefined()
-    await goWasmClose()
-    expect(wasmExitSpy).toHaveBeenCalledWith(0)
-  })
+    return expect(goWasmExec(WasmHooks.genKey)).resolves.toBeDefined()
+  }, 5000)
 })
+it('Should exit on process when closing WASM with non empty event queue', async done => {
+  jest.spyOn(process, 'exit').mockImplementation()
+  const spy = {
+    exit: jest.spyOn(process, 'exit').mockImplementation(),
+  }
+  setTimeout(async () => {
+    try {
+      await goWasmExec(WasmHooks.genKey)
+    } catch (e) {
+      expect(e.message).toContain('Go program has already exited')
+      done()
+    }
+    return done
+  }, 9000)
+  await expect(goWasmClose()).resolves.toBe(1)
+  expect(spy.exit).toHaveBeenCalledWith(0)
+}, 10_000)

--- a/src/wasm/wasm_exec_wrapper.ts
+++ b/src/wasm/wasm_exec_wrapper.ts
@@ -26,8 +26,8 @@ const goWasmExec = <T>(
   args?: Array<string | number | boolean>
 ): Promise<T> =>
   Promise.resolve(GoInstance)
-    .then(wasm => wasm.execWasmFn(goHook, args))
-    .catch(e => {
+    .then((wasm) => wasm.execWasmFn(goHook, args))
+    .catch((e) => {
       // catches unresolved wasm calls despite calling goWasmClose
       if (isClosed) {
         process.exit(0)


### PR DESCRIPTION
## fixes #35 + improves closing of WASM

- fix KILTprotocol/ticket/issues/342
- moved Go channel out of `main` scope
- added closing function that can be called from Js
- added error handling in case someone closes the Wasm but still has unresolved Wasm callbacks

## How to test:
```
yarn test
```
## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
