### PR TITLE
Add tutorial examples to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 on: [push]
 jobs:
-  testgo:
+  test_go:
     name: Go Tests
     runs-on: ubuntu-latest
     steps:
@@ -39,7 +39,7 @@ jobs:
           name: wasm
           path: ../../../go/src/github.com/${{ github.repository }}/build/wasm/main.wasm
 
-  testts:
+  test_jest:
     runs-on: ubuntu-latest
     name: TS Tests
     needs: testgo
@@ -74,7 +74,7 @@ jobs:
         env:
           CI: true
 
-  testintegration:
+  test_integration:
     runs-on: ubuntu-latest
     name: integration tests
     needs: testgo
@@ -106,7 +106,7 @@ jobs:
         env:
           CI: true
 
-  testexamples:
+  test_examples:
     runs-on: ubuntu-latest
     name: example tests
     needs: testgo
@@ -139,5 +139,37 @@ jobs:
           yarn ts-node docs/examples/exampleCombined.chain.ts
           yarn ts-node docs/examples/readme.ts
           docker stop $(docker ps -f ancestor=kiltprotocol/portablegabi-node -q)
+        env:
+          CI: true
+
+  test_tutorial:
+    runs-on: ubuntu-latest
+    name: test tutorial code
+    needs: testgo
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+
+      - name: Download wasm for Go Tests
+        uses: actions/download-artifact@v1
+        with:
+          name: wasm
+
+      - name: Use Node.js 10.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10
+
+      - name: yarn install and test
+        run: |
+          mkdir -p build
+          ls
+          mv wasm build/wasm
+          yarn install --frozen-lockfile
+          yarn ts-node docs/examples/tutorial/tutorial.ts
+          docker run -d --rm -p 9944:9944 kiltprotocol/portablegabi-node --dev --ws-port 9944 --ws-external
+          sleep 5s
+          yarn ts-node docs/examples/tutorial/sections/4_chain.ts
         env:
           CI: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
   test_jest:
     runs-on: ubuntu-latest
     name: TS Tests
-    needs: testgo
+    needs: test_go
 
     strategy:
       matrix:
@@ -77,7 +77,7 @@ jobs:
   test_integration:
     runs-on: ubuntu-latest
     name: integration tests
-    needs: testgo
+    needs: test_go
 
     steps:
       - name: Check out code
@@ -109,7 +109,7 @@ jobs:
   test_examples:
     runs-on: ubuntu-latest
     name: example tests
-    needs: testgo
+    needs: test_go
 
     steps:
       - name: Check out code
@@ -145,7 +145,7 @@ jobs:
   test_tutorial:
     runs-on: ubuntu-latest
     name: test tutorial code
-    needs: testgo
+    needs: test_go
 
     steps:
       - name: Check out code

--- a/docs/examples/tutorial/sections/1_attestation.ts
+++ b/docs/examples/tutorial/sections/1_attestation.ts
@@ -1,0 +1,76 @@
+import * as portablegabi from '../../../../src'
+import { testEnv1 } from '../../exampleConfig'
+
+const pubKey = new portablegabi.AttesterPublicKey(testEnv1.pubKey)
+const privKey = new portablegabi.AttesterPrivateKey(testEnv1.privKey)
+
+/**
+ * In case you have to change something here, please copy paste the inside of this function (without return)
+ * to 2_attestation.md below privKey generation L#37 of the tutorial example
+ */
+export default async function tutorialAttestation() {
+  const attester = new portablegabi.Attester(pubKey, privKey)
+
+  // Create a new accumulator (which is used for revocation).
+  const accumulator = await attester.createAccumulator()
+  console.log('Accumulator:\n\t', accumulator.toString())
+
+  // Build a new claimer and generate a new master key.
+  // const claimer = await portablegabi.Claimer.create()
+  // or use a mnemonic:
+  const claimer = await portablegabi.Claimer.buildFromMnemonic(
+    'siege decrease quantum control snap ride position strategy fire point airport include'
+  )
+
+  // The attester initiates the attestation session.
+  const {
+    message: startAttestationMsg,
+    session: attestationSession,
+  } = await attester.startAttestation()
+
+  // The claimer answers with an attestation request.
+  const claim = {
+    age: 15,
+    name: 'George',
+  }
+
+  const {
+    message: attestationRequest,
+    session: claimerSession,
+  } = await claimer.requestAttestation({
+    // The received attestation message.
+    startAttestationMsg,
+    // The claim which should get attested.
+    claim,
+    // The public key of the attester.
+    attesterPubKey: attester.publicKey,
+  })
+
+  // The attester should check the claim they are about to attest.
+  const receivedClaim = attestationRequest.getClaim()
+  console.log('Claim built from attestation\n\t', receivedClaim)
+
+  // Do checks on receivedClaim.
+  // If everything checks out the attester issues an attestation.
+  const {
+    // The attestation should be sent over to the claimer.
+    attestation,
+    // The witness should be stored for later revocation.
+    witness,
+  } = await attester.issueAttestation({
+    attestationSession,
+    attestationRequest,
+    // The update is used to generate a non-revocation witness.
+    accumulator,
+  })
+  console.log('Witness:\n\t', witness.toString())
+
+  // After the claimer has received their attestation, they can build their credential.
+  const credential = await claimer.buildCredential({
+    claimerSession,
+    attestation,
+  })
+  console.log('Credential:\n\t', credential.toString())
+
+  return { pubKey, attester, claimer, credential, accumulator, witness }
+}

--- a/docs/examples/tutorial/sections/2_verification.ts
+++ b/docs/examples/tutorial/sections/2_verification.ts
@@ -1,0 +1,56 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import * as portablegabi from '../../../../src'
+
+/**
+ * In case you have to change something here, please copy paste the inside of this function (without return)
+ * to 3_verification.md below pubKey generation L#55 of the tutorial example
+ */
+export default async function tutorialVerification({
+  pubKey,
+  attester,
+  claimer,
+  credential,
+  accumulator,
+}: any) {
+  // The verifier requests a presentation.
+  const {
+    // Local information used to verify the presentation later.
+    session: verifierSession,
+    // The request which should be sent to the claimer containing the requested attributes.
+    message: presentationReq,
+  } = await portablegabi.Verifier.requestPresentation({
+    // Specify which attributes should be disclosed.
+    requestedAttributes: ['age'],
+    // The threshold for the age of the accumulator.
+    // If the accumulator was created before this date, the proof will be rejected
+    // except if the accumulator is the newest available accumulator.
+    reqUpdatedAfter: new Date(),
+  })
+
+  // After the claimer has received the presentationRequest, they build a presentation:
+  const presentation = await claimer.buildPresentation({
+    credential,
+    presentationReq,
+    attesterPubKey: pubKey,
+  })
+  console.log('Presentation:\n\t', presentation.toString())
+
+  // The presentation is sent over to the verifier who validates the proof and extracts the claim.
+  const {
+    // The contained claim, this value is undefined if the proof could not be validated.
+    claim: publicClaim,
+    // A boolean which indicates whether the presentation was valid.
+    verified,
+  } = await portablegabi.Verifier.verifyPresentation({
+    // The presentation which was sent over by the claimer.
+    proof: presentation,
+    verifierSession,
+    // The public key which was used by the attester to sign the credential.
+    attesterPubKey: pubKey,
+    // This accumulator is used to check whether the claimer provided the newest available accumulator.
+    latestAccumulator: accumulator,
+  })
+  console.log('Public claim:\n\t', publicClaim)
+  console.log('Verified?', verified)
+  return true
+}

--- a/docs/examples/tutorial/sections/3_revocation.ts
+++ b/docs/examples/tutorial/sections/3_revocation.ts
@@ -1,0 +1,37 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+/**
+ * In case you have to change something here, please copy paste the inside of this function (without return)
+ * to 4_revocation.md L#32-39 of the tutorial example
+ */
+export default async function tutorialRevocation({
+  pubKey: attestersPublicKey,
+  attester,
+  credential,
+  accumulator: accPreRevo,
+  witness: witnessToBeRevoked,
+}: any) {
+  // Issue attestations and store witnesses.
+  const accPostRevo = await attester.revokeAttestation({
+    accumulator: accPreRevo,
+    // The list of witnesses associated with the credentials which should get revoked.
+    witnesses: [witnessToBeRevoked],
+  })
+  console.log('Accumulator after revocation:\n\t', accPostRevo.toString())
+  // Publish the accumulator after revocation.
+
+  try {
+    const newCredential = await credential.update({
+      attesterPubKey: attestersPublicKey,
+      accumulators: [accPostRevo],
+    })
+    console.log('newCredential:\n\t', newCredential)
+  } catch (e) {
+    if (e.message.includes('updateAllCredential')) {
+      console.log(
+        'Caught expected throw when trying to update the revoked credential'
+      )
+    } else throw e
+  }
+  return true
+}

--- a/docs/examples/tutorial/sections/4_chain.ts
+++ b/docs/examples/tutorial/sections/4_chain.ts
@@ -1,0 +1,183 @@
+import * as portablegabi from '../../../../src'
+
+const privKey = new portablegabi.AttesterPrivateKey(
+  '{"XMLName":{"Space":"","Local":""},"Counter":0,"ExpiryDate":1610554062,"P":"iDYKxuFGt1Xv1aqMLaagjrOPX0hjkOlFrKOp4NPnSBHmQ9SFETUX1M43q3jLsGz+UEWFS3+SS9QpP4CTkl3p/w==","Q":"92MJOhwjESn7QohCCY1oBxsToAfccGoKtE3sBoaNxHWoowSiCy8fMG+B1sO5QU+bV3i1xwvVno9o30RcMoXEaw==","PPrime":"RBsFY3CjW6r36tVGFtNQR1nHr6QxyHSi1lHU8GnzpAjzIepCiJqL6mcb1bxl2DZ/KCLCpb/JJeoUn8BJyS70/w==","QPrime":"e7GEnQ4RiJT9oUQhBMa0A42J0APuODUFWib2A0NG4jrUUYJRBZePmDfA62HcoKfNq7xa44Xqz0e0b6IuGULiNQ==","ECDSA":"MHcCAQEEILO+g4uSDheZ6PSLxR7olFzUhZpeO9tQu84hX6UeIevaoAoGCCqGSM49AwEHoUQDQgAEKvmUz3HIZy890jE78CC9V9BuN8taO+L8GjAeS14v0CL7GCFZ1GMnaSZi4WG3mOjJlJ80CnMowIbUT3Fw1TluFw==","NonrevSk":null}'
+)
+const pubKey = new portablegabi.AttesterPublicKey(
+  '{"XMLName":{"Space":"","Local":""},"Counter":0,"ExpiryDate":1610554062,"N":"g6DWNN/cWep9/lCc6gg0tA8wS1y5LgQx2/fM/wMpYJE8MTZ9SJ3y9kjIBAeSb4aY3vsFhRp8aWsEZzAA0Qu0kW4bzyKN1RU7A0tlmkmDetCxu7Gy2zQMHlTg4YkAVxVYAIIIWhHKHrVLzH7zCsuXos1qm/sthByVdEXv4HPjCZU=","Z":"BiDMFSNGKLIcHJY3tmh2vgiW7D3f5g5b+6Bjf0ns3/rPOg8x0BJ+CzqOLQL+loNIomOzBm/Pk36q3pmPPFMfug80AwUlZOvKTrzj29Agq4DF7p4jruElRyZsdGNjlFkVzILFT/9yrXfjD/9DAHXGm6/4unVnwKP4I0j1r9sLYtg=","S":"Bxm9bNpNLZUM6gy74aR0HW2DadFuy/l+MOdZkG2BiFxbTEP24GXBYA3+d1xajplWEm2iLF4w2OeviIpr8VIzDNy6dXRyGcTnGzj6sVeGlR5u3N+8M2XNH1pNEymLQQbUAt3ogYSWiJW88bxHCf3AZiS91XT1Zh3ENCS9NsyGzt8=","G":"Angd7BuIjTeWGsVLGVCtv+5dx1TMEUr/Z5Fhk7OFUNBexY8fuNfzxfeclgSQpC+nyIAFHc3RB+3Fcs2vOSygopVfLEJo9h7dSjtlcxSZ1wE8YNgouHwfVuq4KWixzIk7Le+IeUzNaQNOL9SI3h5mlxJ5QOO2Src+BPQuFjXPSfI=","H":"U1MyQqwl1LrZY5G61Z2ZDM3zWQKv78HOluCrtxCDBsMvYNRLvhbppOhOdsnG3axN5NIH01/R6mlYojBDg9L7xSwR+1QpmHGUbwkemADlUZQ9c98Up1ORKxNW0asQJdPHV4NGqjQbDfJzejdGJwd95scmSpqLNvRTT+L0iW0ln4A=","T":"BEIUJ5pXzFZPeoB3us341EWxwE7HByM4NaPYRS6YVtDcJdz+H9EEKdUcXhUVrJAQ2OZy2FP0+SNvQVk8AxWDiD73tHUUKDnkMoKSkHPnEnsCInGHr4iTYE2zp8/uEBFxNppq5SP9gQOzE2qekGket2co0W/+jKNtg63u1udlZjo=","R":["OpuoX8xEvGaULH7ir3G/W9zBB1gmYN6lllJsk8+QGGQxydbrtoQiFfhU1Tyqm59sq3GIhksiYB6Th6jYq3BIFKVynX993FPYU2HS2dceFk5kvymIx33u2nTyMzFvox2b6IkKHKXfbtx/VWWlVYcywFOAOiQ1Xa7dXDx1ebuGowE=","Jamoy887kQjyTKjHwgFGxOKugcGIxdUhK9pE/nDTFttU6ndo5qm04AVB5n4WUaFurrKlNSIICheAXI10kIy37Ogr1N4Ge/7TbyZ/hXB8DBzoJbD3MVpXblq9hrhEkb+yyJ9uipnKckflQBWGzl+grXV17SWVhd5TKpUrMw1cDYs=","YGogpko2T4xWQjipZN691tpWJYffyX5evzh2EJAZSpP3evnMbro0Et5Bk+2NY9yt/GoJW8qkVkwEdaYU0jQiGS27F3aJ5e00VOCnZ6bIXJKgcTTxqc5c9NrpJVWNX9n5G590OVTNqlLUOFw3/mIY26A2MKxsa56j2K0V4IM0FI4=","Jca8++mT6d93MK0S8Fb6rtu7TpV9TGqM0mSvO0JKuyRvEro3anRbvZ8sHRLt2q2ePIyCQHz2eUc4iJ1vQLnzMxVavQ3xS5AAS27Tw+xM64JhWV6BFDqZgaEcu22jEi+Rrjjqss2nmC6CQYJZt5g5P0dXGV2JKDcrUaGCtzc4cNE=","ZIV6MWKglRL5B9vv5RmBigbieiuebmy/mcpycXlyQcoZEeNCzuGs/JgRnGr05umbcsQ5ZNSS3TKiL5CM/Z4fanuSu6jNnVoHvSkxI3x28ZpMV8C43CXkS6smmiZP+2SSL419Q247ZbP04T5wHcZ6GooCLxnfx5DeEtRze3UU1Wk=","IbwQtY9iF7C/rNKkTilHP5jEj9r3aI1tRVU9WeMzE9yxrE0mggzpcoCM0lJFLcqVyWhKD3PWssuXwNiLJipUL+sH/u8Qk8Bu6sv/USlUU7sgSJ4akl2Lp+5oYSkzHiZTeJtLg0OVGZnka3pGxzg0ihkkT6Bdk8K2OicTNxlHzgI=","ZQ9/qIgvOx/8dyXlAFeZH+2lriSPaj/NDzPCxR9sXqBYJskSkSrdGogxP2RZeAGyDh7NvwUtvBDQ/vLKz/O3ANPUOnaRx1n4uBF+uBdt0h3Ml/DckhL5k2+nHQsnZWPFxkdpatCIFWcvYuldx+gXLePBaRmNnKMoxAgT+tJnJcw=","ZGfBOqHujseUhLZdfs8kq+/kmG3yMwUAmQrGgTdNej8npNsOyD/Am/SoPdSjpr1enuMgBzva/bjn3/z8nncpia65+v9Pn5831UuFp8h53/1WaEHvN/yctnIKb8k1IRtPlSvnfq7qwC/sIGvHq+ZTj3/ie57rTSkSMrmdFL8PMM0=","TM38T4ekWiNWICCgry7GsppfVt2ImPv4SL//f/J3beP34K1afJCsHk50XJwi8qyMz8HqEVK2sWvMQzJ8Amct4sAfRYIZNmqH7mSR7LwIXvihwv1dUlJv2R7MLTjEGkEnJHE5cCR0K5GxjeQSSgNHAu33MOth3ipsK9ZmF+slSkI=","YwMb/IVn2NsA4y8ZiiBxCWoOg0tsqyYKTakxDZnRhw+wHwhnA3+T87X4tOSAx+dYlmtj3UQzUAeFRYztr2YTrF2boS/YFeAiVh6swPgFOScvmOuf5O4fJn7z+iXr+ivgFccswxBhxqa9MdF8ReqHaVouj8LLyk33fZgWduwfnA=="],"EpochLength":432000,"Params":{"LePrime":120,"Lh":256,"Lm":256,"Ln":1024,"Lstatzk":80,"Le":597,"LeCommit":456,"LmCommit":592,"LRA":1104,"LsCommit":593,"Lv":1700,"LvCommit":2036,"LvPrime":1104,"LvPrimeCommit":1440},"Issuer":"","ECDSA":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKvmUz3HIZy890jE78CC9V9BuN8taO+L8GjAeS14v0CL7GCFZ1GMnaSZi4WG3mOjJlJ80CnMowIbUT3Fw1TluFw==","NonrevPk":null}'
+)
+
+/**
+ * In case you have to change something here, please copy paste the the entire exec function
+ * to 5_with_chain.md below the key generation L#66 of the tutorial example
+ */
+async function exec() {
+  /** (1) Chain phase */
+  // (1.1) Connect to the chain.
+  const chain = await portablegabi.connect({
+    pgabiModName: 'portablegabi',
+  })
+  console.log('Successfully connected to the chain')
+
+  // (1.2) Create Alice identity.
+  const attester = await portablegabi.AttesterChain.buildFromURI(
+    pubKey,
+    privKey,
+    '//Alice',
+    'ed25519'
+  )
+
+  // (1.3) Create a fresh accumulator.
+  const accPreRevo = await attester.createAccumulator()
+
+  // (1.4) Put the accumulator on chain.
+  console.log('Putting accumulator on the chain for Alice')
+  await attester.updateAccumulator(accPreRevo)
+
+  // Check whether it has actually been added to chain.
+  // We need to wait for next block since updating the accumulator is a transaction.
+  console.log('\t Waiting for next block to have the accumulator on the chain')
+  console.log(
+    'Latest accumulator === accPreRevo? Expected true, received',
+    (await chain.getLatestAccumulator(attester.address)).valueOf() ===
+      accPreRevo.valueOf()
+  )
+
+  /** (2) Attestation phase */
+  // (2.1) The attester initiates the attestation session.
+  const {
+    message: startAttestationMsg,
+    session: attestationSession,
+  } = await attester.startAttestation()
+
+  // (2.2) The claimer answers with an attestation request.
+  const claimer = await portablegabi.Claimer.buildFromMnemonic(
+    'siege decrease quantum control snap ride position strategy fire point airport include'
+  )
+  const claim = {
+    name: 'George Ericson',
+    age: 24,
+    driversLicense: {
+      id: '127128204193',
+      category: 'B2',
+      licensingAuthority: 'Berlin A52452',
+    },
+  }
+  const {
+    message: attestationRequest,
+    session: claimerSession,
+  } = await claimer.requestAttestation({
+    // the received attestation message
+    startAttestationMsg,
+    // the claim which should get attested
+    claim,
+    // the public key of the attester
+    attesterPubKey: attester.publicKey,
+  })
+
+  // (2.3) The attester issues an attestation.
+  const {
+    // The attestation should be sent over to the claimer.
+    attestation,
+    // The witness should be stored for later revocation.
+    witness,
+  } = await attester.issueAttestation({
+    attestationSession,
+    attestationRequest,
+    // The update is used to generate a non-revocation witness.
+    accumulator: accPreRevo,
+  })
+  const credential = await claimer.buildCredential({
+    claimerSession,
+    attestation,
+  })
+
+  /** (3) Revocation phase */
+
+  // Revoke the attestation and receive a new accumulator whitelist.
+  const accPostRevo = await attester.revokeAttestation({
+    witnesses: [witness],
+    accumulator: accPreRevo,
+  })
+  // Check whether accPostRevo is the latest accumulator on chain.
+  console.log(
+    '\t Waiting for next block to have the updated accumulator on the chain'
+  )
+  console.log(
+    'Latest accumulator === accPostRevo? Expected true, received',
+    (await chain.getLatestAccumulator(attester.address)).valueOf() ===
+      accPostRevo.valueOf()
+  )
+
+  /** (4) Verification phase */
+  // Get the exact timestamp of the revocation for simplicity, also works for dates after accumulator date.
+  const timeAtRev = await accPostRevo.getDate(attester.publicKey)
+
+  // (4.1) The verifier sends a nonce and context to the claimer and requests disclosed attributes.
+  // Note: The requested timestamp equals the accumulator date.
+  const {
+    session: verifierSession,
+    message: presentationReq,
+  } = await portablegabi.Verifier.requestPresentation({
+    requestedAttributes: ['age', 'driversLicense.category'],
+    reqUpdatedAfter: timeAtRev,
+  })
+
+  // (4.2) The claimer builds a presentation with the revoked credential.
+  // Note: They need to update as the credential was build before timeAtRev.
+  const presentation = await claimer.buildPresentation({
+    credential,
+    presentationReq,
+    attesterPubKey: attester.publicKey,
+  })
+
+  // (4.3) The verifier checks the presentation for non-revocation, valid data and matching attester's public key.
+
+  // We expect success because the credential is still valid in accPreRevo.
+  const {
+    verified: verifiedPreRevo,
+  } = await portablegabi.Verifier.verifyPresentation({
+    proof: presentation,
+    verifierSession,
+    attesterPubKey: attester.publicKey,
+    latestAccumulator: accPreRevo,
+  })
+  console.log(
+    'Cred verified w/ timestamp at revocation and old accumulator?\n\tExpected true, received',
+    verifiedPreRevo
+  )
+
+  // We expect failure because the credential is invalid in accPostRevo.
+  const {
+    verified: verifiedPostRevo,
+  } = await portablegabi.Verifier.verifyPresentation({
+    proof: presentation,
+    verifierSession,
+    attesterPubKey: attester.publicKey,
+    latestAccumulator: accPostRevo,
+  })
+  console.log(
+    'Cred verified w/ timestamp at revocation and new accumulator?\n\tExpected false, received',
+    verifiedPostRevo
+  )
+
+  // Expect failure when updating a credential whose witness was revoked in any of the used accumulators.
+  await credential
+    .updateSingle({
+      attesterPubKey: attester.publicKey,
+      accumulator: accPostRevo,
+    })
+    .catch((e) => {
+      if (e.message.includes('updateCredential')) {
+        console.log(
+          'Caught expected throw when trying to update the revoked credential'
+        )
+      } else throw e
+    })
+}
+console.group('\n#### [4/4] On-chain tutorial ####')
+exec().finally(async () => {
+  await portablegabi.disconnect()
+  console.groupEnd()
+  console.log('Done with on-chain')
+})

--- a/docs/examples/tutorial/tutorial.ts
+++ b/docs/examples/tutorial/tutorial.ts
@@ -1,0 +1,49 @@
+import tutorialAttestation from './sections/1_attestation'
+import tutorialVerification from './sections/2_verification'
+import tutorialRevocation from './sections/3_revocation'
+
+async function main() {
+  const results = []
+  console.group('#### [1/4] Attestation tutorial ####')
+  const {
+    pubKey,
+    attester,
+    claimer,
+    credential,
+    accumulator,
+    witness,
+  } = await tutorialAttestation()
+  results.push(
+    pubKey && attester && claimer && credential && accumulator && witness
+  )
+  console.groupEnd()
+  console.group('\n#### [2/4] Verification tutorial ####')
+  results.push(
+    await tutorialVerification({
+      pubKey,
+      attester,
+      claimer,
+      credential,
+      accumulator,
+    })
+  )
+  console.groupEnd()
+  console.group('\n#### [3/4] Revocation tutorial ####')
+  results.push(
+    await tutorialRevocation({
+      pubKey,
+      attester,
+      claimer,
+      credential,
+      accumulator,
+      witness,
+    })
+  )
+  console.groupEnd()
+  if (results.length !== 3 || !results.every(Boolean)) {
+    throw new Error(`Did not receive expected results: ${results.toString()}`)
+  }
+  console.log('Done with off-chain')
+}
+
+main()


### PR DESCRIPTION
## Adds tutorial code examples to CI
- adds code examples from Portablegabi tutorial to CI tests
- runs off-chain examples in sequential order in _tutorial.ts_ and checks whether each section was executed correctly by checking for `true` return
- runs on-chain examples

## How to test:
CI pipeline should run.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
