### PR TITLE
fix: wasmData serialization

### DIFF
--- a/docs/examples/tutorial/sections/4_chain.ts
+++ b/docs/examples/tutorial/sections/4_chain.ts
@@ -39,8 +39,8 @@ async function exec(): Promise<void> {
   console.log('\t Waiting for next block to have the accumulator on the chain')
   console.log(
     'Latest accumulator === accPreRevo? Expected true, received',
-    (await chain.getLatestAccumulator(attester.address)).valueOf() ===
-      accPreRevo.valueOf()
+    (await chain.getLatestAccumulator(attester.address)).toString() ===
+      accPreRevo.toString()
   )
 
   /** (2) Attestation phase */
@@ -110,8 +110,8 @@ async function exec(): Promise<void> {
   )
   console.log(
     'Latest accumulator === accPostRevo? Expected true, received',
-    (await chain.getLatestAccumulator(attester.address)).valueOf() ===
-      accPostRevo.valueOf()
+    (await chain.getLatestAccumulator(attester.address)).toString() ===
+      accPostRevo.toString()
   )
 
   /** (4) Verification phase */

--- a/src/attestation/Accumulator.ts
+++ b/src/attestation/Accumulator.ts
@@ -1,5 +1,5 @@
 import { AttesterPublicKey } from '../types/Attestation'
-import goWasmExec from '../wasm/wasm_exec_wrapper'
+import goWasmExec, { wasmStringify } from '../wasm/wasm_exec_wrapper'
 import WasmHooks from '../wasm/WasmHooks'
 import WasmData from '../types/Wasm'
 
@@ -16,7 +16,7 @@ export default class Accumulator extends WasmData {
   public async getDate(attesterPublicKey: AttesterPublicKey): Promise<Date> {
     const timestamp = await goWasmExec<string>(
       WasmHooks.getAccumulatorTimestamp,
-      [attesterPublicKey.toString(), this.toString()]
+      [wasmStringify(attesterPublicKey), this.toString()]
     )
     return new Date(JSON.parse(timestamp))
   }

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -6,6 +6,7 @@ import { SubmittableExtrinsic } from '@polkadot/api/types'
 import BlockchainError from './BlockchainError'
 import { IBlockchainApi, IPortablegabiApi, PgabiModName } from '../types/Chain'
 import Accumulator from '../attestation/Accumulator'
+import { wasmStringify } from '../wasm/wasm_exec_wrapper'
 
 /**
  * The Blockchain class provides an interface for querying and creating transactions on chain.
@@ -181,7 +182,9 @@ export default class Blockchain implements IBlockchainApi {
   public buildUpdateAccumulatorTX(
     accumulator: Accumulator
   ): SubmittableExtrinsic<'promise'> {
-    return this.api.tx[this.chainmod].updateAccumulator(accumulator.toString())
+    return this.api.tx[this.chainmod].updateAccumulator(
+      wasmStringify(accumulator)
+    )
   }
 
   /**

--- a/src/claim/Claimer.ts
+++ b/src/claim/Claimer.ts
@@ -21,7 +21,7 @@ import {
   CombinedPresentationRequest,
   PresentationRequest,
 } from '../types/Verification'
-import goWasmExec from '../wasm/wasm_exec_wrapper'
+import goWasmExec, { wasmStringify } from '../wasm/wasm_exec_wrapper'
 import Credential from './Credential'
 
 /**
@@ -139,8 +139,8 @@ export default class Claimer implements IClaimer {
       [
         this.secret,
         JSON.stringify(claim),
-        startAttestationMsg.toString(),
-        attesterPubKey.toString(),
+        wasmStringify(startAttestationMsg),
+        wasmStringify(attesterPubKey),
       ]
     )
     return {
@@ -167,8 +167,8 @@ export default class Claimer implements IClaimer {
     return new Credential(
       await goWasmExec<string>(WasmHooks.buildCredential, [
         this.secret,
-        claimerSession.toString(),
-        attestation.toString(),
+        wasmStringify(claimerSession),
+        wasmStringify(attestation),
       ])
     )
   }
@@ -195,9 +195,9 @@ export default class Claimer implements IClaimer {
     return new Presentation(
       await goWasmExec<string>(WasmHooks.buildPresentation, [
         this.secret,
-        credential.toString(),
-        presentationReq.toString(),
-        attesterPubKey.toString(),
+        wasmStringify(credential),
+        wasmStringify(presentationReq),
+        wasmStringify(attesterPubKey),
       ])
     )
   }
@@ -227,7 +227,7 @@ export default class Claimer implements IClaimer {
       await goWasmExec<string>(WasmHooks.buildCombinedPresentation, [
         this.secret,
         `[${credentials.join(',')}]`,
-        combinedPresentationReq.toString(),
+        wasmStringify(combinedPresentationReq),
         `[${attesterPubKeys.join(',')}]`,
       ])
     )

--- a/src/claim/Credential.ts
+++ b/src/claim/Credential.ts
@@ -1,4 +1,4 @@
-import goWasmExec from '../wasm/wasm_exec_wrapper'
+import goWasmExec, { wasmStringify } from '../wasm/wasm_exec_wrapper'
 import WasmHooks from '../wasm/WasmHooks'
 import Accumulator from '../attestation/Accumulator'
 import { AttesterPublicKey } from '../types/Attestation'
@@ -30,8 +30,8 @@ export default class Credential extends WasmData {
     return new Credential(
       await goWasmExec<string>(WasmHooks.updateCredential, [
         this.toString(),
-        accumulator.toString(),
-        attesterPubKey.toString(),
+        wasmStringify(accumulator),
+        wasmStringify(attesterPubKey),
       ])
     )
   }
@@ -56,7 +56,7 @@ export default class Credential extends WasmData {
       await goWasmExec<string>(WasmHooks.updateAllCredential, [
         this.toString(),
         `[${accumulators.join(',')}]`,
-        attesterPubKey.toString(),
+        wasmStringify(attesterPubKey),
       ])
     )
   }
@@ -134,6 +134,6 @@ export default class Credential extends WasmData {
   }
 
   public parse<T>(): ICredential<T> {
-    return JSON.parse(this.toString())
+    return JSON.parse(wasmStringify(this))
   }
 }

--- a/src/types/Attestation.ts
+++ b/src/types/Attestation.ts
@@ -4,6 +4,7 @@ import { SubmittableExtrinsic } from '@polkadot/api/types'
 import Accumulator from '../attestation/Accumulator'
 import WasmData from './Wasm'
 import { AttestationRequest } from './Claim'
+import { wasmStringify } from '../wasm/wasm_exec_wrapper'
 
 export type KeyLength = 1024 | 2048 | 4096
 export const DEFAULT_MAX_ATTRIBUTES = 70
@@ -88,7 +89,7 @@ export class Witness extends WasmData {
  */
 export class Attestation extends WasmData {
   public parse(): IIssueAttestation {
-    return JSON.parse(this.toString())
+    return JSON.parse(wasmStringify(this))
   }
 }
 

--- a/src/types/Claim.ts
+++ b/src/types/Claim.ts
@@ -2,18 +2,19 @@
 /* eslint-disable camelcase */
 /* eslint-disable max-classes-per-file */
 
-import WasmData from './Wasm'
+import Credential from '../claim/Credential'
+import { wasmStringify } from '../wasm/wasm_exec_wrapper'
 import {
+  Attestation,
+  AttesterPublicKey,
   IIssueAttestation,
   InitiateAttestationRequest,
-  AttesterPublicKey,
-  Attestation,
 } from './Attestation'
-import Credential from '../claim/Credential'
 import {
-  PresentationRequest,
   CombinedPresentationRequest,
+  PresentationRequest,
 } from './Verification'
+import WasmData from './Wasm'
 
 export default interface IClaimer {
   requestAttestation: ({
@@ -163,7 +164,7 @@ export class ClaimerAttestationSession extends WasmData {
  */
 export class Presentation extends WasmData {
   public parse(): IProof {
-    return JSON.parse(this.toString())
+    return JSON.parse(wasmStringify(this))
   }
 }
 

--- a/src/types/Wasm.ts
+++ b/src/types/Wasm.ts
@@ -50,10 +50,10 @@ export interface IGoWasm {
  * A wrapper for data received from WASM callbacks.
  */
 export default class WasmData {
-  private data: string
+  private wasmData: string
 
-  public constructor(data: string) {
-    this.data = data
+  public constructor(wasmData: string) {
+    this.wasmData = wasmData
   }
 
   /**
@@ -62,7 +62,7 @@ export default class WasmData {
    * @returns An object of the serialized data string.
    */
   public parse(): { [key: string]: any } {
-    return JSON.parse(this.data)
+    return JSON.parse(this.wasmData)
   }
 
   /**
@@ -71,6 +71,6 @@ export default class WasmData {
    * @returns A string of the WASM data which can be serialized.
    */
   public toString(): string {
-    return this.data
+    return this.wasmData
   }
 }

--- a/src/wasm/wasm_exec_wrapper.spec.ts
+++ b/src/wasm/wasm_exec_wrapper.spec.ts
@@ -1,7 +1,8 @@
-import goWasmExec, { goWasmClose } from './wasm_exec_wrapper'
+import goWasmExec, { goWasmClose, wasmStringify } from './wasm_exec_wrapper'
 import WasmHooks from './WasmHooks'
 import { Spy } from '../testSetup/testTypes'
 import { WasmError } from './wasm_exec'
+import WasmData from '../types/Wasm'
 
 describe('Test WASM wrapper', () => {
   let spy: Spy<''>
@@ -53,3 +54,20 @@ it('Should exit on process when closing WASM with non empty event queue', async 
   await expect(goWasmClose()).resolves.toBe(1)
   expect(spy.exit).toHaveBeenCalledWith(0)
 }, 10_000)
+it('Should stringify any argument for wasm usage', () => {
+  const obj = { x: '1' }
+  const str = JSON.stringify(obj)
+  const wasmData = new WasmData(str)
+  // the case we want
+  expect(wasmStringify(wasmData)).toBe(str)
+  // should return the the serialized object
+  expect(wasmStringify(str)).toBe(str)
+  // should return the serialized object
+  expect(wasmStringify(obj)).toBe(str)
+  // this happens when deserializing a serialized instance of WasmData
+  expect(wasmStringify({ wasmData: str })).toBe(str)
+  // edge case of above
+  expect(wasmStringify({ wasmData: obj })).toBe(
+    JSON.stringify({ wasmData: obj })
+  )
+})

--- a/src/wasm/wasm_exec_wrapper.ts
+++ b/src/wasm/wasm_exec_wrapper.ts
@@ -3,7 +3,7 @@
  * @packageDocumentation
  */
 import WasmHooks from './WasmHooks'
-import { IGoWasm } from '../types/Wasm'
+import WasmData, { IGoWasm } from '../types/Wasm'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const goWasm = require('./wasm_exec')
@@ -54,6 +54,33 @@ export const goWasmClose = async (): Promise<void> => {
   wasm.close()
   // closes Go channel
   return goWasmExec<void>(WasmHooks.closeWasm)
+}
+
+/**
+ * A wrapper function to stringify an instance of [[WasmData]] or a dictionary.
+ *
+ * Reason: When shallow cloning OR deserializing a serialized instance of [[WasmData]],
+ * the `[[WasmData.toString]]` method does not exist anymore or it might be overwritten by [[Object.toString]].
+ *
+ * @param arg The argument which should be stringified.
+ * @returns A stringified version of the argument.
+ */
+export const wasmStringify = (
+  arg: Record<string, unknown> | WasmData | string
+): string => {
+  // already stringified
+  if (typeof arg === 'string') {
+    return arg
+  }
+  // the instance we actually want
+  if (arg instanceof WasmData) {
+    return arg.toString()
+  }
+  return 'wasmData' in arg && typeof arg.wasmData === 'string'
+    ? // due to deserialization of a serialized instance of WasmData is lost s.t. `toString()` does not exist
+      arg.wasmData
+    : // input was never an instance of WasmData
+      JSON.stringify(arg)
 }
 
 export default goWasmExec


### PR DESCRIPTION
## fixes issue of stringifying WasmData when the instance is lost
This problem occured in the SDK when an instance of `WasmData` was serialized and subsequently deserialized. This removes the `WasmData` instance and leads to `WasmData.toString()` being overwritten or not existing. Since we have to serialize all data inside of `WasmData` before sending it to the WASM, this PR should fix this.

## How to test:
```
yarn test -t "Should stringify any argument for wasm usage"

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
