### PR TITLE
chore: update polkadot types

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,10 +58,10 @@
     "url": "git+https://github.com/KILTprotocol/portablegabi.git"
   },
   "dependencies": {
-    "@polkadot/api": "^1.20.1",
+    "@polkadot/api": "^1.21.1",
     "@polkadot/keyring": "^2.15.1",
-    "@polkadot/rpc-provider": "^1.20.1",
-    "@polkadot/types": "^1.20.1",
+    "@polkadot/rpc-provider": "^1.21.1",
+    "@polkadot/types": "^1.21.1",
     "@polkadot/util": "^2.15.1",
     "@polkadot/util-crypto": "^2.15.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -464,35 +464,35 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@polkadot/api-derive@1.20.1":
-  version "1.20.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-1.20.1.tgz#6cff4ca28b89d991b11dcde157ecd816e4435dfc"
-  integrity sha512-ujuej+1NesC2hDFpcljcSQQiLCPwpFD0w3zKMhZfw7/Uls12xAcZHBa6hrI2MO7UFkwR1HPpOTrWnZoBPN0C+A==
+"@polkadot/api-derive@1.21.1":
+  version "1.21.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-1.21.1.tgz#b68c4e46f8a02371c3b325744088e07b594d9f63"
+  integrity sha512-f0fNZOWIZMBmX3aqX3seVIyV4RnPeerFgIi2i1ZBRLYGJQ/VghwfVl2H0ooGUCOhe99Vp6AkKcr7KyEoSBoEPw==
   dependencies:
     "@babel/runtime" "^7.10.3"
-    "@polkadot/api" "1.20.1"
-    "@polkadot/rpc-core" "1.20.1"
-    "@polkadot/rpc-provider" "1.20.1"
-    "@polkadot/types" "1.20.1"
+    "@polkadot/api" "1.21.1"
+    "@polkadot/rpc-core" "1.21.1"
+    "@polkadot/rpc-provider" "1.21.1"
+    "@polkadot/types" "1.21.1"
     "@polkadot/util" "^2.15.1"
     "@polkadot/util-crypto" "^2.15.1"
     bn.js "^5.1.2"
     memoizee "^0.4.14"
     rxjs "^6.5.5"
 
-"@polkadot/api@1.20.1", "@polkadot/api@^1.20.1":
-  version "1.20.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-1.20.1.tgz#0700f5ffb1a0d768642cba3db863c631a71e4ce5"
-  integrity sha512-NvUpAOo4zur2wqR01monHfhA4gU+jevlMVquZrq2F+yLKPrqXFVofZ/lxIX3BW7A/X4H8T05G3a7ZRGSD/IjmQ==
+"@polkadot/api@1.21.1", "@polkadot/api@^1.21.1":
+  version "1.21.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-1.21.1.tgz#35b171a948c0c83996950936d52a0a23d0350fd0"
+  integrity sha512-wR3dOoTzEVoxb8y2/mWs0MMxMnbIKQ+6ZfCStmHkc6pMNfkTnFTl72dm2qTXcBGwJr9Ack8qY0Rvs8yN9Xh41A==
   dependencies:
     "@babel/runtime" "^7.10.3"
-    "@polkadot/api-derive" "1.20.1"
+    "@polkadot/api-derive" "1.21.1"
     "@polkadot/keyring" "^2.15.1"
-    "@polkadot/metadata" "1.20.1"
-    "@polkadot/rpc-core" "1.20.1"
-    "@polkadot/rpc-provider" "1.20.1"
-    "@polkadot/types" "1.20.1"
-    "@polkadot/types-known" "1.20.1"
+    "@polkadot/metadata" "1.21.1"
+    "@polkadot/rpc-core" "1.21.1"
+    "@polkadot/rpc-provider" "1.21.1"
+    "@polkadot/types" "1.21.1"
+    "@polkadot/types-known" "1.21.1"
     "@polkadot/util" "^2.15.1"
     "@polkadot/util-crypto" "^2.15.1"
     bn.js "^5.1.2"
@@ -508,39 +508,39 @@
     "@polkadot/util" "2.15.1"
     "@polkadot/util-crypto" "2.15.1"
 
-"@polkadot/metadata@1.20.1":
-  version "1.20.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.20.1.tgz#d1f614ea27571b78040edc04126c35ae82d2bc96"
-  integrity sha512-1pGWg0vamdKbLOlL2GreJBylr+t+Oj/GNdTnB9vdWStD0lenn2eI5Mo+3B9F4x1GbA3TCBghRdRn0thOgLka6w==
+"@polkadot/metadata@1.21.1":
+  version "1.21.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.21.1.tgz#82780f2fabfdf5da9d8acc9b85e11d04350c47ab"
+  integrity sha512-pSYpskRZu7/Vn1dDdv6G+fuOfeYCm97Nkv8BmWkkxuO6oiAorNOnjba5DrjMTz7ivVEOJxYDChYZrY3qZpPS5A==
   dependencies:
     "@babel/runtime" "^7.10.3"
-    "@polkadot/types" "1.20.1"
-    "@polkadot/types-known" "1.20.1"
+    "@polkadot/types" "1.21.1"
+    "@polkadot/types-known" "1.21.1"
     "@polkadot/util" "^2.15.1"
     "@polkadot/util-crypto" "^2.15.1"
     bn.js "^5.1.2"
 
-"@polkadot/rpc-core@1.20.1":
-  version "1.20.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-1.20.1.tgz#3aa0e8184b80bdcb2e5a95a80a37586c02594163"
-  integrity sha512-+TjAXPwa9cxfQgFYvONdMBWLucQ2txqekkySZiOAPiLWT8gRUc3Y9S/l1b3mhPK6cx6/nhdGgsd2rkc3pREp+Q==
+"@polkadot/rpc-core@1.21.1":
+  version "1.21.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-1.21.1.tgz#1255227395c6b27dcf9cea6fe99d5f992914ed65"
+  integrity sha512-fItWRGJ0B6u1oGLH0IgvUPVeBI2AUsfmwtchXoCpw+mlVUExb9rZoI0pGhkTC1ptDr/fuNicF3NS79weWoo0xQ==
   dependencies:
     "@babel/runtime" "^7.10.3"
-    "@polkadot/metadata" "1.20.1"
-    "@polkadot/rpc-provider" "1.20.1"
-    "@polkadot/types" "1.20.1"
+    "@polkadot/metadata" "1.21.1"
+    "@polkadot/rpc-provider" "1.21.1"
+    "@polkadot/types" "1.21.1"
     "@polkadot/util" "^2.15.1"
     memoizee "^0.4.14"
     rxjs "^6.5.5"
 
-"@polkadot/rpc-provider@1.20.1", "@polkadot/rpc-provider@^1.20.1":
-  version "1.20.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-1.20.1.tgz#5019bcfee266921d4c4b9d090fe8971a2496be99"
-  integrity sha512-OTenT4DX9/P63Hwsm2cccSRtHT2gY4MMACqXOUpAwLuPqeTcI07jpHbRbRuWYkRtPWCHwTORfyxzp6B6onkQSw==
+"@polkadot/rpc-provider@1.21.1", "@polkadot/rpc-provider@^1.21.1":
+  version "1.21.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-1.21.1.tgz#60354eca890a2af30236297169e4b8ae85c6eba0"
+  integrity sha512-yz/t1Beduzz3fR1xa+JlNJKEMvKIQdN4vpuGCJDQyfKrd+jGn5gV3irg2VaT23guiXEhPC1f+NP0hlOBW7bIsA==
   dependencies:
     "@babel/runtime" "^7.10.3"
-    "@polkadot/metadata" "1.20.1"
-    "@polkadot/types" "1.20.1"
+    "@polkadot/metadata" "1.21.1"
+    "@polkadot/types" "1.21.1"
     "@polkadot/util" "^2.15.1"
     "@polkadot/util-crypto" "^2.15.1"
     bn.js "^5.1.2"
@@ -548,23 +548,23 @@
     isomorphic-fetch "^2.2.1"
     websocket "^1.0.31"
 
-"@polkadot/types-known@1.20.1":
-  version "1.20.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-1.20.1.tgz#8bfbc66d0ca24185c81b8a9453f015b3988360b6"
-  integrity sha512-rY6r0tRHKTeeDljpK/UjXu+FHmeZt3bZ5I25nCHeoO98SrJEn+twbUSlQQpzanTNSBzKeWepsxuaWSUMDYa7dA==
+"@polkadot/types-known@1.21.1":
+  version "1.21.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-1.21.1.tgz#500a96cce0b41a944f69be45c96e4e7f3e965507"
+  integrity sha512-ZAdZ/kXDz3YG1uYkocbSXWB1z/gjI8JRiDFEhcwqjCRU1+retokpZ786QuXG0JBaU74FES4ZTs+maqYjS4jcBw==
   dependencies:
     "@babel/runtime" "^7.10.3"
-    "@polkadot/types" "1.20.1"
+    "@polkadot/types" "1.21.1"
     "@polkadot/util" "^2.15.1"
     bn.js "^5.1.2"
 
-"@polkadot/types@1.20.1", "@polkadot/types@^1.20.1":
-  version "1.20.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-1.20.1.tgz#f2b5d3be3038b5efd7545dad5889dbc9f8bc0166"
-  integrity sha512-AHsfTZ4ejUDISMVMtyuRU8/r+cpo/dy/emvbD0ZKMZ4F7igqFV9aADzHVPDGO93Qm0jHJlT8pOCN+OoDGm6MAg==
+"@polkadot/types@1.21.1", "@polkadot/types@^1.21.1":
+  version "1.21.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-1.21.1.tgz#2c72cb5a7305abf97e5531b9bcd3f040f05aa4e1"
+  integrity sha512-mzRxufZHBsVwxD4KC1mERV4zsvwGdw7anNSr/+q/LT7tHKlQNQLnITlUXgZh7NgvD6MOeCw68QW/iSel1YXsKg==
   dependencies:
     "@babel/runtime" "^7.10.3"
-    "@polkadot/metadata" "1.20.1"
+    "@polkadot/metadata" "1.21.1"
     "@polkadot/util" "^2.15.1"
     "@polkadot/util-crypto" "^2.15.1"
     "@types/bn.js" "^4.11.6"


### PR DESCRIPTION
## Updates polkadot types to 1.21.1 from 1.20.1

## How to test:
```bash
yarn test
```
## Checklist:

- [x] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
