### PR TITLE
publish full releases to GitHub Packages

### DIFF
--- a/.github/workflows/devpackpublish.yml
+++ b/.github/workflows/devpackpublish.yml
@@ -72,6 +72,6 @@ jobs:
           CI: true
 
       - run: yarn version --no-git-tag-version --prerelease --preid $(git rev-parse --short HEAD)
-      - run: yarn publish --tag dev
+      - run: yarn publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,6 +75,16 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
+      - name: publish to github packages
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10
+          registry-url: https://npm.pkg.github.com
+
+      - run: yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish-api:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## no ticket
In order to solve the problem with installing the latest ghp builds of the sdk, this publishes portablegabi full releases to npm as well as ghp.
This fix also tackles the issue that the prereleases published to ghp were tagged as `dev`, which means they are _not_ tagged as `latest`. This may have been the cause of the problem that yarn did not automatically install the latest package.

## How to test:
The latter fix will show already when we push to develop.
The former however will only be visible with the next release.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
